### PR TITLE
image coverage: per-master audit CSV + 95% CI gate

### DIFF
--- a/scripts/check-exit-criteria.ts
+++ b/scripts/check-exit-criteria.ts
@@ -28,6 +28,20 @@ import { assessCoverageAudit } from "./coverage-audit-status";
 
 const RAW_DIR = path.join(process.cwd(), "scripts/data/raw");
 const PREVIEW_LIMIT = 10;
+const DEFAULT_IMAGE_COVERAGE_THRESHOLD = 95;
+
+function parseCoverageThreshold(): number {
+  const raw = process.env.IMAGE_COVERAGE_THRESHOLD;
+  if (raw === undefined || raw === "") return DEFAULT_IMAGE_COVERAGE_THRESHOLD;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    console.warn(
+      `IMAGE_COVERAGE_THRESHOLD="${raw}" is not a valid percentage; falling back to ${DEFAULT_IMAGE_COVERAGE_THRESHOLD}.`
+    );
+    return DEFAULT_IMAGE_COVERAGE_THRESHOLD;
+  }
+  return parsed;
+}
 
 interface RawDatasetAudit {
   filename: string;
@@ -226,6 +240,7 @@ async function main() {
         id: mediaAssets.id,
         entityType: mediaAssets.entityType,
         entityId: mediaAssets.entityId,
+        type: mediaAssets.type,
       })
       .from(mediaAssets),
     db
@@ -270,6 +285,24 @@ async function main() {
   );
 
   const imageIds = new Set([...mediaMasterIds]);
+
+  const citedMediaAssetIds = new Set(
+    allCitations
+      .filter((citation) => citation.entityType === "media_asset")
+      .map((citation) => citation.entityId)
+  );
+  const citedImageMasterIds = new Set(
+    allMedia
+      .filter(
+        (asset) => asset.entityType === "master" && citedMediaAssetIds.has(asset.id)
+      )
+      .map((asset) => asset.entityId)
+  );
+  const portraitMediaIds = new Set(
+    allMedia
+      .filter((asset) => asset.entityType === "master" && asset.type === "image")
+      .map((asset) => asset.entityId)
+  );
 
   const studentIds = new Set(allTransmissions.map((edge) => edge.studentId));
   const teacherIds = new Set(allTransmissions.map((edge) => edge.teacherId));
@@ -411,6 +444,20 @@ async function main() {
   printMetric(
     "Masters with images",
     `${imageIds.size} / ${totalMasters} (${formatPercent(imageIds.size, totalMasters)})`
+  );
+  printMetric(
+    "Masters with cited images",
+    `${citedImageMasterIds.size} / ${totalMasters} (${formatPercent(
+      citedImageMasterIds.size,
+      totalMasters
+    )})`
+  );
+  printMetric(
+    "Masters with real portrait",
+    `${portraitMediaIds.size} / ${totalMasters} (${formatPercent(
+      portraitMediaIds.size,
+      totalMasters
+    )})`
   );
   printMetric(
     "Contemporary masters with images",
@@ -621,6 +668,36 @@ async function main() {
       "Provenance issues",
       `${provenanceWarnings.length + provenanceErrors.length} raw datasets need attention`
     );
+  }
+
+  // ── Image-coverage gate ──────────────────────────────────────────────
+  // Hard threshold: every master must end up with a cited media asset
+  // (real portrait or name-card placeholder). Configurable via
+  // IMAGE_COVERAGE_THRESHOLD (percentage, 0–100; default 95). Set to 0
+  // to disable. Returns a non-zero exit code when coverage regresses
+  // below the threshold so CI fails noisily.
+  const threshold = parseCoverageThreshold();
+  const coveragePct = totalMasters === 0 ? 100 : (citedImageMasterIds.size / totalMasters) * 100;
+  console.log("\nImage coverage gate");
+  printMetric("Threshold", `${threshold.toFixed(1)}%`);
+  printMetric(
+    "Cited image coverage",
+    `${citedImageMasterIds.size} / ${totalMasters} (${coveragePct.toFixed(1)}%)`
+  );
+  if (threshold > 0 && coveragePct < threshold) {
+    const missingCited = allMasters
+      .filter((master) => !citedImageMasterIds.has(master.id))
+      .map((master) => master.slug)
+      .sort();
+    console.error(
+      `\nERROR: cited image coverage ${coveragePct.toFixed(1)}% is below threshold ${threshold.toFixed(1)}%.`
+    );
+    console.error(`  ${missingCited.length} masters lack a cited media_asset:`);
+    console.error(`    ${preview(missingCited)}`);
+    console.error(
+      `  Run scripts/generate-name-placeholders.ts (or land a real portrait) to restore coverage.`
+    );
+    process.exit(1);
   }
 }
 

--- a/scripts/image-coverage-audit.csv
+++ b/scripts/image-coverage-audit.csv
@@ -1,0 +1,416 @@
+slug,name,school,birth_year,death_year,era,coverage,storage_path,source,license,citation_source,notes
+alfred-jitsudo-ancheta,Alfred Jitsudo Ancheta,white-plum-asanga,,,unknown,placeholder,/masters/alfred-jitsudo-ancheta.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ananda,Ananda,indian-patriarchs,-450,,ancient,portrait,/masters/ananda.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+anne-seisen-saunders,Anne Seisen Saunders,white-plum-asanga,,,unknown,placeholder,/masters/anne-seisen-saunders.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+aryadeva,Aryadeva,indian-patriarchs,170,270,ancient,portrait,/masters/aryadeva.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+ashvaghosha,Ashvaghosha,indian-patriarchs,80,150,ancient,portrait,/masters/ashvaghosha.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+baian-hakujun-kuroda,Baian Hakujun Kuroda,soto,1898,1978,modern,portrait,/masters/baian-hakujun-kuroda.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+baiyun-shouduan,Baiyun Shouduan,yangqi-line,,,unknown,placeholder,/masters/baiyun-shouduan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baizan-monpon,Baizan Monpon,soto,,,unknown,placeholder,/masters/baizan-monpon.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baizhang-huaihai,Baizhang Huaihai,nanyue-line,,,unknown,portrait,/masters/baizhang-huaihai.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+baizhang-niepan,Baizhang Niepan,linji,,,unknown,placeholder,/masters/baizhang-niepan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+bajiao-huiqing,Bajiao Huiqing,caodong,,,unknown,placeholder,/masters/bajiao-huiqing.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baling-haojian,Baling Haojian,yunmen,,,unknown,placeholder,/masters/baling-haojian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+bankei-yotaku,Bankei Yotaku,rinzai,1622,1693,early-modern,portrait,/masters/bankei-yotaku.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+banryo-zenso,Banryo Zenso,rinzai,1849,1918,modern,placeholder,/masters/banryo-zenso.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baoci-xingyan,Baoci Xingyan,qingyuan-line,,,unknown,placeholder,/masters/baoci-xingyan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baoen-xuanze,Baoen Xuanze,nanyue-line,,,unknown,placeholder,/masters/baoen-xuanze.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baofeng-weizhao,Baofeng Weizhao,guiyang,,,unknown,placeholder,/masters/baofeng-weizhao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baofu-congzhan,Baofu Congzhan,qingyuan-line,,928,classical,placeholder,/masters/baofu-congzhan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baoning-renyong,Baoning Renyong,linji,,,unknown,placeholder,/masters/baoning-renyong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baoshou-yanzhao,Baoshou Yanzhao,linji,,,unknown,placeholder,/masters/baoshou-yanzhao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+baotang-wuzhu,Baotang Wuzhu,early-chan,,,unknown,portrait,/masters/baotang-wuzhu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+bassui-tokusho,Bassui Tokusho,rinzai,1327,1387,medieval,portrait,/masters/bassui-tokusho.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+bernie-tetsugen-glassman,Bernie Tetsugen Glassman,white-plum-asanga,1939,2018,modern,portrait,/masters/bernie-tetsugen-glassman.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+bokuo-soun,Bokuo Soun,rinzai,1903,1991,modern,placeholder,/masters/bokuo-soun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+brad-warner,Brad Warner,soto,,,unknown,portrait,/masters/brad-warner.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+buddhamitra,Buddhamitra,indian-patriarchs,-150,,ancient,portrait,/masters/buddhamitra.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+buddhanandi,Buddhanandi,indian-patriarchs,-150,,ancient,portrait,/masters/buddhanandi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+butsumon-sogaku,Butsumon Sogaku,soto,1858,1933,modern,placeholder,/masters/butsumon-sogaku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+caoshan-benji,Caoshan Benji,caodong,840,901,classical,portrait,/masters/caoshan-benji.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+changfu-zhi,Changfu Zhi,qingyuan-line,,,unknown,placeholder,/masters/changfu-zhi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+changlu-qingliao,Changlu Qingliao,caodong,,,unknown,placeholder,/masters/changlu-qingliao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+changqing-huileng,Changqing Huileng,qingyuan-line,854,932,classical,placeholder,/masters/changqing-huileng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+changsha-jingcen,Changsha Jingcen,caodong,,,unknown,placeholder,/masters/changsha-jingcen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+changshui-zixuan,Changshui Zixuan,caodong,,,unknown,placeholder,/masters/changshui-zixuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+charlotte-joko-beck,Charlotte Joko Beck,white-plum-asanga,1917,2011,modern,placeholder,/masters/charlotte-joko-beck.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chengtian-chuanzong,Chengtian Chuanzong,yunmen,,,unknown,placeholder,/masters/chengtian-chuanzong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chingak-hyesim,Chin'gak Hyesim,jogye,1178,1234,medieval,placeholder,/masters/chingak-hyesim.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chokoku-koen,Chokoku Koen,soto,,,unknown,placeholder,/masters/chokoku-koen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chongshou-qichou,Chongshou Qichou,qingyuan-line,,,unknown,placeholder,/masters/chongshou-qichou.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chozan-ginetsu,Chozan Ginetsu,soto,1581,1672,early-modern,placeholder,/masters/chozan-ginetsu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chuanzi-decheng,Chuanzi Decheng,qingyuan-line,,,unknown,placeholder,/masters/chuanzi-decheng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+chuzan-ryoun,Chuzan Ryoun,soto,1350,1432,medieval,placeholder,/masters/chuzan-ryoun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+cizhou-faru,Cizhou Faru,early-chan,,,unknown,placeholder,/masters/cizhou-faru.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+cuiwei-wuxue,Cuiwei Wuxue,qingyuan-line,,,unknown,placeholder,/masters/cuiwei-wuxue.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+cuiyan-kezhen,Cuiyan Kezhen,linji,,,unknown,placeholder,/masters/cuiyan-kezhen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+cuiyan-lingcan,Cuiyan Lingcan,caodong,,,unknown,placeholder,/masters/cuiyan-lingcan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+d-t-suzuki,D.T. Suzuki,rinzai,1870,1966,modern,portrait,/masters/d-t-suzuki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+daguang-juhui,Daguang Juhui,qingyuan-line,837,903,classical,placeholder,/masters/daguang-juhui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dagui-muzhe,Dagui Muzhe,caodong,,,unknown,placeholder,/masters/dagui-muzhe.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dahong-zuzheng,Dahong Zuzheng,linji,,,unknown,placeholder,/masters/dahong-zuzheng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dahui-zonggao,Dahui Zonggao,linji,,,unknown,portrait,/masters/dahui-zonggao.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+daiki-kyokan,Daiki Kyokan,soto,,,unknown,placeholder,/masters/daiki-kyokan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dainin-katagiri,Dainin Katagiri,soto,1928,1990,modern,portrait,/masters/dainin-katagiri.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+daisetsu-joen,Daisetsu Joen,rinzai,1797,1855,early-modern,placeholder,/masters/daisetsu-joen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+daishin-kan-yu,Daishin Kan'yu,soto,,,unknown,placeholder,/masters/daishin-kan-yu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+daishitsu-chisen,Daishitsu Chisen,soto,1461,1536,medieval,placeholder,/masters/daishitsu-chisen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dajian-huineng,Dajian Huineng,early-chan,638,713,classical,portrait,/masters/dajian-huineng.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+daman-hongren,Daman Hongren,early-chan,602,675,classical,portrait,/masters/daman-hongren.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+damei-fachang,Damei Fachang,nanyue-line,,,unknown,placeholder,/masters/damei-fachang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+danxia-tianran,Danxia Tianran,qingyuan-line,738,824,classical,portrait,/masters/danxia-tianran.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+danxia-zichun,Danxia Zichun,caodong,,,unknown,portrait,/masters/danxia-zichun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+danyuan-yingzhen,Danyuan Yingzhen,qingyuan-line,,,unknown,placeholder,/masters/danyuan-yingzhen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+daowu-yuanzhi,Daowu Yuanzhi,qingyuan-line,769,835,classical,placeholder,/masters/daowu-yuanzhi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dasui-fazhen,Dasui Fazhen,nanyue-line,,,unknown,placeholder,/masters/dasui-fazhen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dayang-jingxuan,Dayang Jingxuan,caodong,,,unknown,portrait,/masters/dayang-jingxuan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dayi-daoxin,Dayi Daoxin,early-chan,580,651,classical,portrait,/masters/dayi-daoxin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dayu-shouzhi,Dayu Shouzhi,linji,,,unknown,placeholder,/masters/dayu-shouzhi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dazu-huike,Dazu Huike,early-chan,487,593,classical,portrait,/masters/dazu-huike.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dennis-genpo-merzel,Dennis Genpo Merzel,white-plum-asanga,1944,,modern,portrait,/masters/dennis-genpo-merzel.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+deshan-xuanjian,Deshan Xuanjian,qingyuan-line,782,865,classical,portrait,/masters/deshan-xuanjian.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+deshan-yuanmi,Deshan Yuanmi,caodong,,,unknown,placeholder,/masters/deshan-yuanmi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dhritaka,Dhritaka,indian-patriarchs,-250,,ancient,portrait,/masters/dhritaka.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dingzhou-shizang,Dingzhou Shizang,qingyuan-line,,,unknown,placeholder,/masters/dingzhou-shizang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+dogen,Dogen,soto,1200,1253,medieval,portrait,/masters/dogen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dokutan-sosan,Dokutan Sosan,rinzai,1840,1917,modern,portrait,/masters/dokutan-sosan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dongshan-liangjie,Dongshan Liangjie,qingyuan-line,807,869,classical,portrait,/masters/dongshan-liangjie.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+dongshan-shouchu,Dongshan Shouchu,nanyue-line,910,990,classical,placeholder,/masters/dongshan-shouchu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+doushuai-congyue,Doushuai Congyue,linji,,,unknown,placeholder,/masters/doushuai-congyue.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+enjo-gikan,Enjo Gikan,soto,,,unknown,placeholder,/masters/enjo-gikan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+etienne-mokusho-zeisler,Etienne Mokusho Zeisler,soto,,,unknown,placeholder,/masters/etienne-mokusho-zeisler.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+evelyne-eko-de-smedt,Évelyne Ekō de Smedt,soto,,,unknown,placeholder,/masters/evelyne-eko-de-smedt.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+fayan-wenyi,Fayan Wenyi,fayan,885,958,classical,portrait,/masters/fayan-wenyi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+fengxian-daochen,Fengxian Daochen,yunmen,,,unknown,placeholder,/masters/fengxian-daochen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+fengxue-yanzhao,Fengxue Yanzhao,linji,,,unknown,placeholder,/masters/fengxue-yanzhao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+fenyang-shanzhao,Fenyang Shanzhao,linji,,,unknown,portrait,/masters/fenyang-shanzhao.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+foyan-qingyuan,Foyan Qingyuan,yangqi-line,,,unknown,portrait,/masters/foyan-qingyuan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+fuden-gentotsu,Fuden Gentotsu,soto,,,unknown,placeholder,/masters/fuden-gentotsu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+fukushu-kochi,Fukushu Kochi,soto,,,unknown,placeholder,/masters/fukushu-kochi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+furong-daokai,Furong Daokai,caodong,,,unknown,portrait,/masters/furong-daokai.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+fushan-fayuan,Fushan Fayuan,caodong,,,unknown,placeholder,/masters/fushan-fayuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+fuzan-shunki,Fuzan Shunki,soto,,,unknown,placeholder,/masters/fuzan-shunki.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gangoku-gankei,Gangoku Gankei,soto,1683,1767,early-modern,placeholder,/masters/gangoku-gankei.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gaoan-dayu,Gaoan Dayu,yunmen,,,unknown,placeholder,/masters/gaoan-dayu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gaofeng-yuanmiao,Gaofeng Yuanmiao,yangqi-line,1238,1295,medieval,portrait,/masters/gaofeng-yuanmiao.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gasan-jito,Gasan Jito,rinzai,1727,1797,early-modern,portrait,/masters/gasan-jito.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gasan-joseki,Gasan Joseki,soto,1275,1366,medieval,portrait,/masters/gasan-joseki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gayashata,Gayashata,indian-patriarchs,250,,ancient,portrait,/masters/gayashata.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gerry-shishin-wick,Gerry Shishin Wick,white-plum-asanga,1943,,modern,portrait,/masters/gerry-shishin-wick.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gessen-zenne,Gessen Zenne,rinzai,1702,1781,early-modern,placeholder,/masters/gessen-zenne.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gesshu-soko,Gesshu Soko,soto,1618,1696,early-modern,portrait,/masters/gesshu-soko.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gisan-tonin,Gisan Tonin,soto,1386,1462,medieval,placeholder,/masters/gisan-tonin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gisan-zenrai,Gisan Zenrai,rinzai,1802,1878,early-modern,placeholder,/masters/gisan-zenrai.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+giten-gensho,Giten Gensho,rinzai,,,unknown,placeholder,/masters/giten-gensho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gongai-sochu,Gongai Sochu,rinzai,1315,1390,medieval,portrait,/masters/gongai-sochu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+guannan-daochang,Guannan Daochang,caodong,,,unknown,placeholder,/masters/guannan-daochang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gudo-toshoku,Gudo Toshoku,rinzai,1577,1661,early-modern,portrait,/masters/gudo-toshoku.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gudo-wafu-nishijima,Gudo Wafu Nishijima,soto,1919,2014,modern,portrait,/masters/gudo-wafu-nishijima.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+guifeng-zongmi,Guifeng Zongmi,early-chan,,,unknown,portrait,/masters/guifeng-zongmi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+guishan-daan,Guishan Daan,nanyue-line,,,unknown,placeholder,/masters/guishan-daan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+guishan-lingyou,Guishan Lingyou,caodong,,,unknown,portrait,/masters/guishan-lingyou.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+guizong-cezhen,Guizong Cezhen,qingyuan-line,,979,classical,placeholder,/masters/guizong-cezhen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+guizong-zhichang,Guizong Zhichang,nanyue-line,,,unknown,placeholder,/masters/guizong-zhichang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gukei-youn,Gukei Youn,soto,,,unknown,placeholder,/masters/gukei-youn.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gyakushitsu-sojun,Gyakushitsu Sojun,soto,,,unknown,placeholder,/masters/gyakushitsu-sojun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+gyeongheo-seongu,Gyeongheo Seongu,seon,1846,1912,modern,portrait,/masters/gyeongheo-seongu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+gyokujun-so-on,Gyokujun So-on,soto,1877,1934,modern,placeholder,/masters/gyokujun-so-on.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+haklena,Haklena,indian-patriarchs,350,,ancient,portrait,/masters/haklena.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+hakuho-genteki,Hakuho Genteki,soto,1594,1670,early-modern,placeholder,/masters/hakuho-genteki.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+hakuin-ekaku,Hakuin Ekaku,rinzai,1686,1769,early-modern,portrait,/masters/hakuin-ekaku.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+hangzhou-tianlong,Hangzhou Tianlong,guiyang,,,unknown,portrait,/masters/hangzhou-tianlong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+harada-daiun-sogaku,Harada Daiun Sogaku,sanbo-zen,1871,1961,modern,portrait,/masters/harada-daiun-sogaku.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+harada-sodo-kakusho,Harada Sodo Kakusho,soto,1844,1931,modern,portrait,/masters/harada-sodo-kakusho.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+heshan-wuyin,Heshan Wuyin,yunmen,,,unknown,placeholder,/masters/heshan-wuyin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+heze-shenhui,Heze Shenhui,early-chan,,,unknown,portrait,/masters/heze-shenhui.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+hogen-soren,Hogen Soren,soto,,,unknown,placeholder,/masters/hogen-soren.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+hongzhi-zhengjue,Hongzhi Zhengjue,caodong,,,unknown,portrait,/masters/hongzhi-zhengjue.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+huangbo-xiyun,Huangbo Xiyun,linji,,,unknown,portrait,/masters/huangbo-xiyun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+huanglong-huiji,Huanglong Huiji,linji,,,unknown,placeholder,/masters/huanglong-huiji.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+huanglong-huinan,Huanglong Huinan,linji,1002,1069,medieval,portrait,/masters/huanglong-huinan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+huguo-jingyuan,Huguo Jingyuan,linji,,,unknown,placeholder,/masters/huguo-jingyuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+huguo-shoucheng,Huguo Shoucheng,guiyang,,,unknown,placeholder,/masters/huguo-shoucheng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+huitang-zuxin,Huitang Zuxin,linji,,,unknown,placeholder,/masters/huitang-zuxin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+huoan-shiti,Huoan Shiti,linji,,,unknown,placeholder,/masters/huoan-shiti.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ian-chisatsu,Ian Chisatsu,rinzai,1514,1587,medieval,placeholder,/masters/ian-chisatsu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ikkyu-sojun,Ikkyu Sojun,rinzai,1394,1481,medieval,portrait,/masters/ikkyu-sojun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+inzan-ien,Inzan Ien,rinzai,1751,1814,early-modern,portrait,/masters/inzan-ien.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+iyoku-choyu,Iyoku Choyu,soto,1416,1502,medieval,placeholder,/masters/iyoku-choyu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jan-chozen-bays,Jan Chozen Bays,white-plum-asanga,1945,,modern,portrait,/masters/jan-chozen-bays.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+jayata,Jayata,indian-patriarchs,350,,ancient,portrait,/masters/jayata.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+jean-pierre-genshu-faure,Jean-Pierre Genshū Faure,soto,1948,,modern,placeholder,/masters/jean-pierre-genshu-faure.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ji-an-xin,Ji'an Xin,yangqi-line,,,unknown,placeholder,/masters/ji-an-xin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jianzhi-sengcan,Jianzhi Sengcan,early-chan,,606,classical,portrait,/masters/jianzhi-sengcan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+jiashan-shanhui,Jiashan Shanhui,qingyuan-line,805,881,classical,placeholder,/masters/jiashan-shanhui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jingqing-daofu,Jingqing Daofu,nanyue-line,868,937,classical,placeholder,/masters/jingqing-daofu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jingzhao-mihu,Jingzhao Mihu,caodong,,,unknown,placeholder,/masters/jingzhao-mihu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jingzhong-shenhui,Jingzhong Shenhui,early-chan,720,794,classical,placeholder,/masters/jingzhong-shenhui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jingzhong-wuxiang,Jingzhong Wuxiang,early-chan,684,762,classical,placeholder,/masters/jingzhong-wuxiang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jinhua-juzhi,Jinhua Juzhi,yunmen,,,unknown,placeholder,/masters/jinhua-juzhi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jinul,Bojo Jinul,jogye,1158,1210,medieval,portrait,/masters/jinul.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+jissan-mokuin,Jissan Mokuin,soto,,,unknown,placeholder,/masters/jissan-mokuin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jiufeng-daoqian,Jiufeng Daoqian,qingyuan-line,,,unknown,placeholder,/masters/jiufeng-daoqian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jiufeng-qin,Jiufeng Qin,guiyang,,,unknown,placeholder,/masters/jiufeng-qin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+jiyu-kennett,Jiyu-Kennett,soto,1924,1996,modern,portrait,/masters/jiyu-kennett.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+jochu-tengin,Jochu Tengin,soto,1363,1437,medieval,placeholder,/masters/jochu-tengin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+john-daido-loori,John Daido Loori,white-plum-asanga,1931,2009,modern,portrait,/masters/john-daido-loori.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+john-tesshin-sanderson,John Tesshin Sanderson,white-plum-asanga,,,unknown,placeholder,/masters/john-tesshin-sanderson.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+joshu-sasaki,Joshu Sasaki,rinzai,1907,2014,modern,portrait,/masters/joshu-sasaki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+joten-soko-miura,Joten Soko Miura,rinzai,1871,1958,modern,placeholder,/masters/joten-soko-miura.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+juefan-huihong,Juefan Huihong,linji,,,unknown,placeholder,/masters/juefan-huihong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+juo-sohitsu,Juo Sohitsu,rinzai,1296,1380,medieval,placeholder,/masters/juo-sohitsu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kaifu-daoning,Kaifu Daoning,linji,,,unknown,placeholder,/masters/kaifu-daoning.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kaiten-genju,Kaiten Genju,soto,,,unknown,placeholder,/masters/kaiten-genju.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kankai-tokuon,Kankai Tokuon,soto,,,unknown,placeholder,/masters/kankai-tokuon.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kanzan-egen,Kanzan Egen,rinzai,1277,1360,medieval,portrait,/masters/kanzan-egen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+kapimala,Kapimala,indian-patriarchs,150,,ancient,portrait,/masters/kapimala.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+karyo-zuika,Karyo Zuika,rinzai,1790,1859,early-modern,placeholder,/masters/karyo-zuika.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kaso-sodon,Kaso Sodon,rinzai,1352,1428,medieval,portrait,/masters/kaso-sodon.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+keido-chisan,Keido Chisan,soto,,,unknown,placeholder,/masters/keido-chisan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+keigan-eisho,Keigan Eisho,soto,1321,1412,medieval,placeholder,/masters/keigan-eisho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+keizan-jokin,Keizan Jokin,soto,1264,1325,medieval,portrait,/masters/keizan-jokin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+ken-an-junsa,Ken'an Junsa,soto,,,unknown,placeholder,/masters/ken-an-junsa.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kinen-horyu,Kinen Horyu,soto,,1506,medieval,placeholder,/masters/kinen-horyu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kobun-chino-otogawa,Kobun Chino Otogawa,soto,1938,2002,modern,portrait,/masters/kobun-chino-otogawa.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+kodo-sawaki,Kodo Sawaki,soto,1880,1965,modern,portrait,/masters/kodo-sawaki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+koho-genkun,Koho Genkun,rinzai,,,unknown,placeholder,/masters/koho-genkun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+koho-kakumyo,Koho Kakumyo,rinzai,1271,1361,medieval,placeholder,/masters/koho-kakumyo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kokei-shojun,Kokei Shojun,soto,,1555,medieval,placeholder,/masters/kokei-shojun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kokoku-soryu,Kokoku Soryu,soto,,,unknown,placeholder,/masters/kokoku-soryu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kono-bukai,Kono Bukai,rinzai,1854,1934,modern,placeholder,/masters/kono-bukai.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kosen-baido,Kosen Baido,soto,,,unknown,placeholder,/masters/kosen-baido.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+kosen-imakita,Kosen Imakita,rinzai,1816,1892,early-modern,portrait,/masters/kosen-imakita.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+kosho-uchiyama,Kosho Uchiyama,soto,1912,1998,modern,portrait,/masters/kosho-uchiyama.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+koun-ejo,Koun Ejo,soto,1198,1280,medieval,portrait,/masters/koun-ejo.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+kumarata,Kumarata,indian-patriarchs,350,,ancient,portrait,/masters/kumarata.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+kumu-daocheng,Kumu Daocheng,caodong,,,unknown,placeholder,/masters/kumu-daocheng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+langye-huijue,Langye Huijue,linji,,,unknown,placeholder,/masters/langye-huijue.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+liangshan-yuanguan,Liangshan Yuanguan,caodong,,,unknown,portrait,/masters/liangshan-yuanguan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+lianhua-fengxiang,Lianhua Fengxiang,yunmen,,,unknown,placeholder,/masters/lianhua-fengxiang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+licun,Licun,linji,,,unknown,placeholder,/masters/licun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+lieu-quan,Liễu Quán,lam-te,1670,1742,early-modern,portrait,/masters/lieu-quan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+lingyun-zhiqin,Lingyun Zhiqin,guiyang,,,unknown,portrait,/masters/lingyun-zhiqin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+linji-yixuan,Linji Yixuan,linji,,866,classical,portrait,/masters/linji-yixuan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+liu-tiemo,Liu Tiemo,yunmen,,,unknown,placeholder,/masters/liu-tiemo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+longji-shaoxiu,Longji Shaoxiu,qingyuan-line,,,unknown,placeholder,/masters/longji-shaoxiu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+longtan-chongxin,Longtan Chongxin,qingyuan-line,,,unknown,portrait,/masters/longtan-chongxin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+longya-judun,Longya Judun,yunmen,,,unknown,placeholder,/masters/longya-judun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+luohan-guichen,Luohan Guichen,qingyuan-line,867,928,classical,portrait,/masters/luohan-guichen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+luopu-yuanan,Luopu Yuanan,qingyuan-line,834,898,classical,placeholder,/masters/luopu-yuanan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+luoshan-daoxian,Luoshan Daoxian,qingyuan-line,,,unknown,placeholder,/masters/luoshan-daoxian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+luzu-baoyun,Luzu Baoyun,nanyue-line,,,unknown,placeholder,/masters/luzu-baoyun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mahakashyapa,Mahakashyapa,indian-patriarchs,-450,,ancient,portrait,/masters/mahakashyapa.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+mahasattva-fu,Mahasattva Fu,early-chan,497,569,classical,portrait,/masters/mahasattva-fu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+manorhita,Manorhita,indian-patriarchs,350,,ancient,portrait,/masters/manorhita.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+mayu-baoche,Mayu Baoche,nanyue-line,,,unknown,placeholder,/masters/mayu-baoche.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mazu-daoyi,Mazu Daoyi,nanyue-line,,,unknown,portrait,/masters/mazu-daoyi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+meido-yuton,Meido Yuton,soto,,,unknown,placeholder,/masters/meido-yuton.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+meiho-sotetsu,Meiho Sotetsu,soto,1277,1350,medieval,portrait,/masters/meiho-sotetsu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+michaka,Michaka,indian-patriarchs,-250,,ancient,portrait,/masters/michaka.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+michel-reiku-bovay,Michel Reikū Bovay,soto,1949,2009,modern,placeholder,/masters/michel-reiku-bovay.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mike-chodo-cross,Mike Chodo Cross,soto,,,unknown,placeholder,/masters/mike-chodo-cross.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mingan-rongxi,Mingan Rongxi,rinzai,,,unknown,portrait,/masters/mingan-rongxi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+mingzhao-deqian,Mingzhao Deqian,qingyuan-line,,,unknown,placeholder,/masters/mingzhao-deqian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mokushi-soen,Mokushi Soen,soto,1673,1746,early-modern,placeholder,/masters/mokushi-soen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+moshan-liaoran,Moshan Liaoran,caodong,,,unknown,placeholder,/masters/moshan-liaoran.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+motsugai-shido,Motsugai Shido,soto,,,unknown,placeholder,/masters/motsugai-shido.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+mugai-keigon,Mugai Keigon,soto,1436,1517,medieval,portrait,/masters/mugai-keigon.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+muin-soin,Muin Soin,rinzai,1326,1410,medieval,placeholder,/masters/muin-soin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+muzhou-daoming,Muzhou Daoming,linji,,,unknown,portrait,/masters/muzhou-daoming.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+myoki-soseki,Myoki Soseki,rinzai,1774,1848,early-modern,placeholder,/masters/myoki-soseki.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nagarjuna,Nagarjuna,indian-patriarchs,150,250,ancient,portrait,/masters/nagarjuna.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nakagawa-soen,Nakagawa Soen,rinzai,1907,1984,modern,portrait,/masters/nakagawa-soen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nampo-gentaku,Nampo Gentaku,soto,,,unknown,placeholder,/masters/nampo-gentaku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nanpu-shaoming,Nanpu Shaoming,rinzai,,,unknown,portrait,/masters/nanpu-shaoming.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nanquan-puyuan,Nanquan Puyuan,nanyue-line,748,835,classical,portrait,/masters/nanquan-puyuan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nanso-shinshu,Nanso Shinshu,soto,,,unknown,placeholder,/masters/nanso-shinshu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nanta-guangyong,Nanta Guangyong,caodong,,,unknown,placeholder,/masters/nanta-guangyong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nanyang-huizhong,Nanyang Huizhong,early-chan,,775,classical,portrait,/masters/nanyang-huizhong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nanyin-shourou,Nanyin Shourou,rinzai,,952,classical,placeholder,/masters/nanyin-shourou.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nanyuan-huiyong,Nanyuan Huiyong,linji,,,unknown,portrait,/masters/nanyuan-huiyong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nanyue-daoxuan,Nanyue Daoxuan,qingyuan-line,,,unknown,placeholder,/masters/nanyue-daoxuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nanyue-huairang,Nanyue Huairang,nanyue-line,,,unknown,portrait,/masters/nanyue-huairang.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nenshitsu-yokaku,Nenshitsu Yokaku,soto,1440,1516,medieval,placeholder,/masters/nenshitsu-yokaku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nicolee-jikyo-mccann,Nicolee Jikyo McCann,white-plum-asanga,,,unknown,placeholder,/masters/nicolee-jikyo-mccann.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+nippo-soshun,Nippo Soshun,rinzai,1367,1448,medieval,placeholder,/masters/nippo-soshun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+niutou-farong,Niutou Farong,early-chan,,,unknown,portrait,/masters/niutou-farong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+nyogen-senzaki,Nyogen Senzaki,rinzai,1876,1958,modern,portrait,/masters/nyogen-senzaki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+ogino-dokuen,Ogino Dokuen,rinzai,1819,1895,early-modern,placeholder,/masters/ogino-dokuen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+olivier-reigen-wang-genh,Olivier Reigen Wang-Genh,soto,1955,,modern,placeholder,/masters/olivier-reigen-wang-genh.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+omori-sogen,Omori Sogen,rinzai,1904,1994,modern,portrait,/masters/omori-sogen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+osaka-koryu,Osaka Koryu,rinzai,1901,1985,modern,portrait,/masters/osaka-koryu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+pang-yun,Pang Yun,other,,,unknown,portrait,/masters/pang-yun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+panshan-baoji,Panshan Baoji,nanyue-line,,,unknown,placeholder,/masters/panshan-baoji.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+parshva,Parshva,indian-patriarchs,-50,,ancient,portrait,/masters/parshva.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+philippe-reiryu-coupey,Philippe Reiryū Coupey,soto,1937,,modern,placeholder,/masters/philippe-reiryu-coupey.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+pierre-reigen-crepon,Pierre Reigen Crépon,soto,,,unknown,placeholder,/masters/pierre-reigen-crepon.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+poan-zuxian,Poan Zuxian,yangqi-line,,,unknown,placeholder,/masters/poan-zuxian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+prajnatara,Prajnatara,indian-patriarchs,450,,ancient,portrait,/masters/prajnatara.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+punyamitra,Punyamitra,indian-patriarchs,450,,ancient,portrait,/masters/punyamitra.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+punyayashas,Punyayashas,indian-patriarchs,-50,,ancient,portrait,/masters/punyayashas.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+puti-damo,Puti Damo,early-chan,,536,classical,portrait,/masters/puti-damo.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+qinglin-shiqian,Qinglin Shiqian,nanyue-line,,904,classical,placeholder,/masters/qinglin-shiqian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+qingxi-hongjin,Qingxi Hongjin,qingyuan-line,,,unknown,placeholder,/masters/qingxi-hongjin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+qingyuan-xingsi,Qingyuan Xingsi,qingyuan-line,,740,classical,portrait,/masters/qingyuan-xingsi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+qinshan-wensui,Qinshan Wensui,guiyang,,,unknown,placeholder,/masters/qinshan-wensui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+rahulata,Rahulata,indian-patriarchs,250,,ancient,portrait,/masters/rahulata.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+raphael-doko-triet,Raphaël Dōkō Triet,soto,1950,,modern,portrait,/masters/raphael-doko-triet.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+renzan-soho,Renzan Soho,soto,,,unknown,placeholder,/masters/renzan-soho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+robert-aitken,Robert Aitken,sanbo-zen,1917,2010,modern,portrait,/masters/robert-aitken.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+roland-rech,Roland Rech,soto,1944,2024,modern,portrait,/masters/roland-rech.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+rosetsu-ryuko,Rosetsu Ryuko,soto,,,unknown,placeholder,/masters/rosetsu-ryuko.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ruben-habito,Ruben Habito,sanbo-zen,1947,,modern,portrait,/masters/ruben-habito.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+ruiyan-shiyan,Ruiyan Shiyan,qingyuan-line,,,unknown,portrait,/masters/ruiyan-shiyan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+ryoen-genseki,Ryoen Genseki,rinzai,1843,1919,modern,placeholder,/masters/ryoen-genseki.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ryuko-ryoshu,Ryuko Ryoshu,soto,,,unknown,placeholder,/masters/ryuko-ryoshu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sanghanandi,Sanghanandi,indian-patriarchs,250,,ancient,portrait,/masters/sanghanandi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+sansheng-huiran,Sansheng Huiran,linji,,,unknown,placeholder,/masters/sansheng-huiran.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sawada-zenko,Sawada Zenko,soto,,,unknown,placeholder,/masters/sawada-zenko.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+seisetsu-genjyo,Seisetsu Genjyo,rinzai,1877,1945,modern,placeholder,/masters/seisetsu-genjyo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sekiso-tesshu,Sekiso Tesshu,soto,,,unknown,placeholder,/masters/sekiso-tesshu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sekko-soshin,Sekko Soshin,rinzai,1408,1486,medieval,placeholder,/masters/sekko-soshin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sengai-gibon,Sengai Gibon,rinzai,1750,1837,early-modern,portrait,/masters/sengai-gibon.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+sengan-bonryu,Sengan Bonryu,soto,,,unknown,placeholder,/masters/sengan-bonryu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+senshu-donko,Senshu Donko,soto,,,unknown,placeholder,/masters/senshu-donko.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+senso-esai,Senso Esai,soto,1409,1475,medieval,placeholder,/masters/senso-esai.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+seongcheol,Toeong Seongcheol,jogye,1912,1993,modern,placeholder,/masters/seongcheol.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+seosan-hyujeong,Seosan Hyujeong,seon,1520,1604,early-modern,portrait,/masters/seosan-hyujeong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+sessan-tetsuzen,Sessan Tetsuzen,soto,,,unknown,placeholder,/masters/sessan-tetsuzen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sesso-hoseki,Sesso Hoseki,soto,,,unknown,placeholder,/masters/sesso-hoseki.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sesso-yuho,Sesso Yuho,soto,,1576,medieval,placeholder,/masters/sesso-yuho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+seung-sahn,Seung Sahn,kwan-um,1927,2004,modern,portrait,/masters/seung-sahn.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shakyamuni-buddha,Shakyamuni Buddha,indian-patriarchs,-563,-483,ancient,portrait,/masters/shakyamuni-buddha.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shanakavasa,Shanakavasa,indian-patriarchs,-450,,ancient,portrait,/masters/shanakavasa.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shanglan-lingchao,Shanglan Lingchao,qingyuan-line,,,unknown,placeholder,/masters/shanglan-lingchao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shaoshan-huanpu,Shaoshan Huanpu,qingyuan-line,,,unknown,placeholder,/masters/shaoshan-huanpu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shengshou-nanyin,Shengshou Nanyin,early-chan,,,unknown,placeholder,/masters/shengshou-nanyin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shexian-guixing,Shexian Guixing,caodong,,,unknown,placeholder,/masters/shexian-guixing.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shibayama-zenkei,Shibayama Zenkei,rinzai,1894,1974,modern,portrait,/masters/shibayama-zenkei.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shido-bunan,Shido Bunan,rinzai,1603,1676,early-modern,portrait,/masters/shido-bunan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shinchi-kakushin,Shinchi Kakushin,rinzai,1207,1298,medieval,portrait,/masters/shinchi-kakushin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shingan-doku,Shingan Doku,soto,1374,1449,medieval,placeholder,/masters/shingan-doku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shishuang-chuyuan,Shishuang Chuyuan,linji,,,unknown,placeholder,/masters/shishuang-chuyuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shishuang-qingzhu,Shishuang Qingzhu,qingyuan-line,807,888,classical,placeholder,/masters/shishuang-qingzhu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shitou-xiqian,Shitou Xiqian,qingyuan-line,700,790,classical,portrait,/masters/shitou-xiqian.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shiwu-qinggong,Shiwu Qinggong,yangqi-line,1272,1352,medieval,portrait,/masters/shiwu-qinggong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shizan-tokuchu,Shizan Tokuchu,soto,,,unknown,placeholder,/masters/shizan-tokuchu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shogaku-kenryu,Shogaku Kenryu,soto,,1485,medieval,placeholder,/masters/shogaku-kenryu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shoju-rojin,Shoju Rojin,rinzai,1642,1721,early-modern,portrait,/masters/shoju-rojin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shoryu-koho,Shoryu Koho,soto,1827,1912,modern,placeholder,/masters/shoryu-koho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shoun-hozui,Shoun Hozui,soto,,,unknown,placeholder,/masters/shoun-hozui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shoushan-xingnian,Shoushan Xingnian,linji,,,unknown,placeholder,/masters/shoushan-xingnian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shugan-dochin,Shugan Dochin,soto,,1387,medieval,placeholder,/masters/shugan-dochin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shuho-myocho,Shuho Myocho,rinzai,1282,1337,medieval,portrait,/masters/shuho-myocho.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shunryu-suzuki,Shunryu Suzuki,soto,1904,1971,modern,portrait,/masters/shunryu-suzuki.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+shushan-kuangren,Shushan Kuangren,qingyuan-line,,,unknown,placeholder,/masters/shushan-kuangren.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+shuzan-shunsho,Shuzan Shunsho,soto,1590,1647,early-modern,placeholder,/masters/shuzan-shunsho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+simha,Simha,indian-patriarchs,450,,ancient,portrait,/masters/simha.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+sixin-wuxin,Sixin Wuxin,yangqi-line,,,unknown,placeholder,/masters/sixin-wuxin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+sohan-genyo,Sohan Genyo,rinzai,1848,1922,modern,placeholder,/masters/sohan-genyo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+songshan-puji,Songshan Puji,early-chan,,,unknown,portrait,/masters/songshan-puji.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+soyen-shaku,Soyen Shaku,rinzai,1860,1919,modern,portrait,/masters/soyen-shaku.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+stephane-kosen-thibaut,Stephane Kosen Thibaut,soto,,,unknown,placeholder,/masters/stephane-kosen-thibaut.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+suizhou-daoyuan,Suizhou Daoyuan,early-chan,,,unknown,placeholder,/masters/suizhou-daoyuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+susan-myoyu-andersen,Susan Myoyu Andersen,white-plum-asanga,,2020,modern,placeholder,/masters/susan-myoyu-andersen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taego-bou,Taego Bou,taego-order,1301,1382,medieval,portrait,/masters/taego-bou.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+taiei-zesho,Taiei Zesho,soto,,,unknown,placeholder,/masters/taiei-zesho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taiga-tankyo,Taiga Tankyo,rinzai,,,unknown,placeholder,/masters/taiga-tankyo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taigen-shigen,Taigen Shigen,rinzai,1768,1837,early-modern,placeholder,/masters/taigen-shigen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taigen-soshin,Taigen Soshin,soto,,,unknown,placeholder,/masters/taigen-soshin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taigu-puyu,Taigu Puyu,other,,,unknown,placeholder,/masters/taigu-puyu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taiping-huiqin,Taiping Huiqin,linji,,,unknown,placeholder,/masters/taiping-huiqin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taisen-deshimaru,Taisen Deshimaru,soto,1914,1982,modern,portrait,/masters/taisen-deshimaru.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+taiyuan-fu,Taiyuan Fu,qingyuan-line,,,unknown,placeholder,/masters/taiyuan-fu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+taizan-maezumi,Taizan Maezumi,soto,1931,1995,modern,portrait,/masters/taizan-maezumi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+takuju-kosen,Takuju Kosen,rinzai,1760,1833,early-modern,portrait,/masters/takuju-kosen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tankai-gensho,Tankai Gensho,rinzai,1811,1898,early-modern,placeholder,/masters/tankai-gensho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tekisui-giboku,Tekisui Giboku,rinzai,1822,1899,early-modern,placeholder,/masters/tekisui-giboku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tenrin-kanshu,Tenrin Kanshu,soto,,,unknown,placeholder,/masters/tenrin-kanshu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tenyu-soen,Tenyu Soen,soto,,,unknown,placeholder,/masters/tenyu-soen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tessan-shikaku,Tessan Shikaku,soto,,1376,medieval,placeholder,/masters/tessan-shikaku.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tetto-giko,Tetto Giko,rinzai,1295,1369,medieval,portrait,/masters/tetto-giko.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tettsu-gikai,Tettsu Gikai,soto,1219,1309,medieval,portrait,/masters/tettsu-gikai.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+thich-nhat-hanh,Thích Nhất Hạnh,plum-village,1926,2022,modern,portrait,/masters/thich-nhat-hanh.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tianhuang-daowu,Tianhuang Daowu,qingyuan-line,748,807,classical,portrait,/masters/tianhuang-daowu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tianping-congyi,Tianping Congyi,qingyuan-line,,,unknown,placeholder,/masters/tianping-congyi.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tiantai-deshao,Tiantai Deshao,fayan,891,972,classical,portrait,/masters/tiantai-deshao.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tiantong-rujing,Tiantong Rujing,caodong,,,unknown,portrait,/masters/tiantong-rujing.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tiantong-zongjue,Tiantong Zongjue,caodong,,,unknown,portrait,/masters/tiantong-zongjue.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tianyi-yihuai,Tianyi Yihuai,yunmen,993,1064,medieval,placeholder,/masters/tianyi-yihuai.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tokuo-ryoko,Tokuo Ryoko,soto,1649,1709,early-modern,placeholder,/masters/tokuo-ryoko.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tongan-daopi,Tongan Daopi,caodong,,,unknown,portrait,/masters/tongan-daopi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tongan-guanzhi,Tongan Guanzhi,caodong,,,unknown,portrait,/masters/tongan-guanzhi.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+tongfeng-anzhu,Tongfeng Anzhu,linji,,,unknown,placeholder,/masters/tongfeng-anzhu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+touzi-datong,Touzi Datong,qingyuan-line,819,914,classical,placeholder,/masters/touzi-datong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+touzi-yiqing,Touzi Yiqing,caodong,,,unknown,portrait,/masters/touzi-yiqing.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+toyo-eicho,Toyo Eicho,rinzai,1428,1504,medieval,placeholder,/masters/toyo-eicho.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tozen-soshin,Tozen Soshin,rinzai,1532,1602,early-modern,placeholder,/masters/tozen-soshin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+tran-nhan-tong,Trần Nhân Tông,truc-lam,1258,1308,medieval,portrait,/masters/tran-nhan-tong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+umpo-zenjo,Umpo Zenjo,rinzai,,,unknown,placeholder,/masters/umpo-zenjo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+ungai-kozan,Ungai Kozan,soto,,,unknown,placeholder,/masters/ungai-kozan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+upagupta,Upagupta,indian-patriarchs,-250,,ancient,portrait,/masters/upagupta.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+vasasita,Vasasita,indian-patriarchs,450,,ancient,portrait,/masters/vasasita.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+vasubandhu,Vasubandhu,indian-patriarchs,316,396,ancient,portrait,/masters/vasubandhu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+vasumitra,Vasumitra,indian-patriarchs,-150,,ancient,portrait,/masters/vasumitra.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+vincent-keisen-vuillemin,Vincent Keisen Vuillemin,soto,,,unknown,placeholder,/masters/vincent-keisen-vuillemin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+vinitaruci,Vinītaruci,thien,,594,classical,placeholder,/masters/vinitaruci.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+vo-ngon-thong,Vô Ngôn Thông,thien,,826,classical,portrait,/masters/vo-ngon-thong.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+wang-yanbin,Wang Yanbin,qingyuan-line,,,unknown,placeholder,/masters/wang-yanbin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+wenshu-yingzhen,Wenshu Yingzhen,caodong,,,unknown,placeholder,/masters/wenshu-yingzhen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+william-nyogen-yeo,William Nyogen Yeo,white-plum-asanga,,,unknown,placeholder,/masters/william-nyogen-yeo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+wufeng-changguan,Wufeng Changguan,nanyue-line,,,unknown,placeholder,/masters/wufeng-changguan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+wujiu-youxuan,Wujiu Youxuan,nanyue-line,,,unknown,placeholder,/masters/wujiu-youxuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+wumen-huikai,Wumen Huikai,linji,,,unknown,placeholder,/masters/wumen-huikai.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+wuzhun-shifan,Wuzhun Shifan,yangqi-line,,,unknown,portrait,/masters/wuzhun-shifan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+wuzu-fayan,Wuzu Fayan,linji,,,unknown,portrait,/masters/wuzu-fayan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xianglin-chengyuan,Xianglin Chengyuan,guiyang,,,unknown,placeholder,/masters/xianglin-chengyuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xiangyan-zhixian,Xiangyan Zhixian,guiyang,,,unknown,placeholder,/masters/xiangyan-zhixian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xinghua-cunjiang,Xinghua Cunjiang,linji,830,888,classical,placeholder,/masters/xinghua-cunjiang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xingyang-qingpou,Xingyang Qingpou,guiyang,,,unknown,placeholder,/masters/xingyang-qingpou.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xingyang-qingrang,Xingyang Qingrang,caodong,,,unknown,placeholder,/masters/xingyang-qingrang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xita-guangmu,Xita Guangmu,linji,,,unknown,placeholder,/masters/xita-guangmu.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xitang-zhizang,Xitang Zhizang,nanyue-line,,,unknown,placeholder,/masters/xitang-zhizang.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xiyuan-siming,Xiyuan Siming,linji,,,unknown,placeholder,/masters/xiyuan-siming.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+xuansha-shibei,Xuansha Shibei,qingyuan-line,835,908,classical,portrait,/masters/xuansha-shibei.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xuedou-chongxian,Xuedou Chongxian,yunmen,980,1052,medieval,portrait,/masters/xuedou-chongxian.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xuedou-zhijian,Xuedou Zhijian,caodong,,,unknown,portrait,/masters/xuedou-zhijian.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xuefeng-yicun,Xuefeng Yicun,qingyuan-line,822,908,classical,portrait,/masters/xuefeng-yicun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xueyan-zuqin,Xueyan Zuqin,yangqi-line,1216,1287,medieval,portrait,/masters/xueyan-zuqin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+xutang-zhiyu,Xutang Zhiyu,yangqi-line,,,unknown,portrait,/masters/xutang-zhiyu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yamada-koun,Yamada Koun,sanbo-zen,1907,1989,modern,portrait,/masters/yamada-koun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yamamoto-gempo,Yamamoto Gempo,rinzai,1866,1961,modern,portrait,/masters/yamamoto-gempo.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yang-wuwei,Yang Wuwei,yunmen,,,unknown,placeholder,/masters/yang-wuwei.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yangqi-fanghui,Yangqi Fanghui,yangqi-line,,,unknown,portrait,/masters/yangqi-fanghui.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yangshan-huiji,Yangshan Huiji,caodong,,,unknown,portrait,/masters/yangshan-huiji.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yangshan-yong,Yangshan Yong,caodong,,,unknown,placeholder,/masters/yangshan-yong.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yanguan-qian,Yanguan Qian,nanyue-line,,,unknown,placeholder,/masters/yanguan-qian.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yantou-quanhuo,Yantou Quanhuo,qingyuan-line,,,unknown,portrait,/masters/yantou-quanhuo.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yanyang-shanxin,Yanyang Shanxin,nanyue-line,,,unknown,placeholder,/masters/yanyang-shanxin.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yaoshan-weiyan,Yaoshan Weiyan,qingyuan-line,751,834,classical,portrait,/masters/yaoshan-weiyan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yasutani-hakuun,Yasutani Hakuun,sanbo-zen,1885,1973,modern,portrait,/masters/yasutani-hakuun.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yongjia-xuanjue,Yongjia Xuanjue,early-chan,,713,classical,portrait,/masters/yongjia-xuanjue.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yongming-yanshou,Yongming Yanshou,fayan,904,975,classical,portrait,/masters/yongming-yanshou.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yozan-keiyo,Yozan Keiyo,rinzai,1559,1629,early-modern,placeholder,/masters/yozan-keiyo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yuantong-fashen,Yuantong Fashen,yunmen,,,unknown,placeholder,/masters/yuantong-fashen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yuanwu-keqin,Yuanwu Keqin,linji,,,unknown,portrait,/masters/yuanwu-keqin.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yuean-shanguo,Yuean Shanguo,linji,,,unknown,placeholder,/masters/yuean-shanguo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yuelin-shiguan,Yuelin Shiguan,linji,,,unknown,placeholder,/masters/yuelin-shiguan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yuezhou-qianfeng,Yuezhou Qianfeng,yunmen,,,unknown,placeholder,/masters/yuezhou-qianfeng.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yunan-kewen,Yunan Kewen,linji,,,unknown,placeholder,/masters/yunan-kewen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yungai-zhiyuan,Yungai Zhiyuan,qingyuan-line,,,unknown,placeholder,/masters/yungai-zhiyuan.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+yunju-daoying,Yunju Daoying,caodong,,902,classical,portrait,/masters/yunju-daoying.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yunmen-wenyan,Yunmen Wenyan,yunmen,864,949,classical,portrait,/masters/yunmen-wenyan.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yunyan-tansheng,Yunyan Tansheng,qingyuan-line,780,841,classical,portrait,/masters/yunyan-tansheng.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yuquan-shenxiu,Yuquan Shenxiu,early-chan,,,unknown,portrait,/masters/yuquan-shenxiu.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+yves-shoshin-crettaz,Yves Shoshin Crettaz,soto,,,unknown,portrait,/masters/yves-shoshin-crettaz.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+zhangjing-huaiyun,Zhangjing Huaiyun,nanyue-line,,,unknown,placeholder,/masters/zhangjing-huaiyun.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zhaozhou-congshen,Zhaozhou Congshen,nanyue-line,778,897,classical,portrait,/masters/zhaozhou-congshen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+zhenjing-kewen,Zhenjing Kewen,linji,,,unknown,placeholder,/masters/zhenjing-kewen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zhenxie-qingliao,Zhenxie Qingliao,caodong,,,unknown,portrait,/masters/zhenxie-qingliao.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+zhimen-guangzuo,Zhimen Guangzuo,guiyang,,,unknown,placeholder,/masters/zhimen-guangzuo.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zhongyi-hongen,Zhongyi Hongen,nanyue-line,,,unknown,placeholder,/masters/zhongyi-hongen.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zhuan-shigui,Zhuan Shigui,yangqi-line,,,unknown,placeholder,/masters/zhuan-shigui.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zifu-rubao,Zifu Rubao,linji,,,unknown,placeholder,/masters/zifu-rubao.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zizhou-chuji,Zizhou Chuji,early-chan,669,736,classical,placeholder,/masters/zizhou-chuji.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)
+zizhou-zhishen,Zizhou Zhishen,early-chan,609,702,classical,portrait,/masters/zizhou-zhishen.webp,wikipedia,cc-by-sa-or-fair-use,src_wikipedia,
+zoden-yoko,Zoden Yoko,soto,,,unknown,placeholder,/masters/zoden-yoko.svg,generated,generated-name-placeholder,src_editorial_biographies,name-card placeholder (no public-domain portrait available)

--- a/scripts/image-coverage-audit.ts
+++ b/scripts/image-coverage-audit.ts
@@ -1,0 +1,253 @@
+/**
+ * Generate scripts/image-coverage-audit.csv — a per-master report on image
+ * coverage. One row per master. The CSV captures whether each master is
+ * served by a real portrait, by an enso/name-card placeholder, or has no
+ * media_asset at all, and links the row back to the citation source so
+ * gaps are auditable.
+ *
+ * Columns:
+ *   slug            — master slug (primary key for cross-referencing)
+ *   name            — English dharma name (best-effort)
+ *   school          — school slug (or empty)
+ *   birth_year, death_year — life range, when known
+ *   era             — ancient / classical / medieval / early-modern / modern
+ *   coverage        — portrait | placeholder | none
+ *   storage_path    — file referenced by media_assets.storage_path
+ *   source          — wikipedia | commons | external | generated | (none)
+ *   license         — license string from media_assets
+ *   citation_source — citations.source_id used to publish the asset
+ *   notes           — short free-text describing why a placeholder was used
+ *                     or any other relevant provenance hint
+ *
+ * Usage:
+ *   DATABASE_URL=file:zen.db npx tsx scripts/image-coverage-audit.ts
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  citations,
+  masterNames,
+  masters,
+  mediaAssets,
+  schools,
+} from "@/db/schema";
+
+const OUT_PATH = path.join(process.cwd(), "scripts", "image-coverage-audit.csv");
+
+function csvCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function eraFor(birth: number | null, death: number | null): string {
+  const year = death ?? birth;
+  if (year == null) return "unknown";
+  if (year < 500) return "ancient";
+  if (year < 1000) return "classical";
+  if (year < 1600) return "medieval";
+  if (year < 1900) return "early-modern";
+  return "modern";
+}
+
+function classifySource(asset: {
+  type: string;
+  attribution: string | null;
+  license: string | null;
+  sourceUrl: string | null;
+}): { source: string; notes: string } {
+  if (asset.type === "placeholder") {
+    return {
+      source: "generated",
+      notes: "name-card placeholder (no public-domain portrait available)",
+    };
+  }
+  const attribution = asset.attribution ?? "";
+  if (/wikipedia/i.test(attribution)) {
+    return { source: "wikipedia", notes: "" };
+  }
+  if (asset.sourceUrl && /commons\.wikimedia\.org/i.test(asset.sourceUrl)) {
+    return { source: "commons", notes: "manually-verified Commons file" };
+  }
+  if (asset.sourceUrl && /^https?:/i.test(asset.sourceUrl)) {
+    return { source: "external", notes: attribution || "external portrait" };
+  }
+  if (asset.license === "cc-by-sa-or-fair-use") {
+    return { source: "wikipedia", notes: "" };
+  }
+  return { source: "curated", notes: attribution };
+}
+
+async function main() {
+  const allMasters = await db
+    .select({
+      id: masters.id,
+      slug: masters.slug,
+      schoolId: masters.schoolId,
+      birthYear: masters.birthYear,
+      deathYear: masters.deathYear,
+    })
+    .from(masters);
+
+  const allNames = await db
+    .select({
+      masterId: masterNames.masterId,
+      locale: masterNames.locale,
+      nameType: masterNames.nameType,
+      value: masterNames.value,
+    })
+    .from(masterNames);
+
+  const namesByMaster = new Map<string, typeof allNames>();
+  for (const row of allNames) {
+    const list = namesByMaster.get(row.masterId) ?? [];
+    list.push(row);
+    namesByMaster.set(row.masterId, list);
+  }
+
+  const schoolRows = await db.select({ id: schools.id, slug: schools.slug }).from(schools);
+  const schoolSlugById = new Map(schoolRows.map((s) => [s.id, s.slug]));
+
+  const allAssets = await db
+    .select({
+      id: mediaAssets.id,
+      entityId: mediaAssets.entityId,
+      entityType: mediaAssets.entityType,
+      type: mediaAssets.type,
+      storagePath: mediaAssets.storagePath,
+      sourceUrl: mediaAssets.sourceUrl,
+      attribution: mediaAssets.attribution,
+      license: mediaAssets.license,
+    })
+    .from(mediaAssets)
+    .where(eq(mediaAssets.entityType, "master"));
+
+  const assetByMaster = new Map<string, (typeof allAssets)[number]>();
+  for (const asset of allAssets) {
+    assetByMaster.set(asset.entityId, asset);
+  }
+
+  const allCitations = await db
+    .select({
+      entityType: citations.entityType,
+      entityId: citations.entityId,
+      sourceId: citations.sourceId,
+    })
+    .from(citations);
+
+  const citationSourceByAsset = new Map<string, string>();
+  for (const cite of allCitations) {
+    if (cite.entityType !== "media_asset") continue;
+    if (!citationSourceByAsset.has(cite.entityId)) {
+      citationSourceByAsset.set(cite.entityId, cite.sourceId);
+    }
+  }
+
+  const sortedMasters = [...allMasters].sort((a, b) => a.slug.localeCompare(b.slug));
+
+  const header = [
+    "slug",
+    "name",
+    "school",
+    "birth_year",
+    "death_year",
+    "era",
+    "coverage",
+    "storage_path",
+    "source",
+    "license",
+    "citation_source",
+    "notes",
+  ];
+
+  const lines = [header.join(",")];
+
+  let portraits = 0;
+  let placeholders = 0;
+  let none = 0;
+
+  for (const master of sortedMasters) {
+    const names = namesByMaster.get(master.id) ?? [];
+    const englishName =
+      names.find((n) => n.locale === "en" && n.nameType === "dharma")?.value ??
+      names.find((n) => n.locale === "en")?.value ??
+      master.slug;
+    const schoolSlug = master.schoolId ? schoolSlugById.get(master.schoolId) ?? "" : "";
+
+    const asset = assetByMaster.get(master.id);
+    let coverage: string;
+    let storagePath = "";
+    let sourceLabel = "";
+    let license = "";
+    let citationSource = "";
+    let notes = "";
+
+    if (!asset) {
+      coverage = "none";
+      none++;
+      notes = "no media_asset row — needs placeholder or curated portrait";
+    } else {
+      storagePath = asset.storagePath ?? "";
+      license = asset.license ?? "";
+      citationSource = citationSourceByAsset.get(asset.id) ?? "";
+      if (asset.type === "placeholder") {
+        coverage = "placeholder";
+        placeholders++;
+      } else {
+        coverage = "portrait";
+        portraits++;
+      }
+      const classified = classifySource({
+        type: asset.type ?? "image",
+        attribution: asset.attribution,
+        license: asset.license,
+        sourceUrl: asset.sourceUrl,
+      });
+      sourceLabel = classified.source;
+      notes = classified.notes;
+    }
+
+    lines.push(
+      [
+        master.slug,
+        englishName,
+        schoolSlug,
+        master.birthYear ?? "",
+        master.deathYear ?? "",
+        eraFor(master.birthYear, master.deathYear),
+        coverage,
+        storagePath,
+        sourceLabel,
+        license,
+        citationSource,
+        notes,
+      ]
+        .map(csvCell)
+        .join(",")
+    );
+  }
+
+  fs.writeFileSync(OUT_PATH, lines.join("\n") + "\n");
+
+  const total = sortedMasters.length;
+  const cited = portraits + placeholders;
+  const pct = total === 0 ? 0 : (cited / total) * 100;
+  const portraitPct = total === 0 ? 0 : (portraits / total) * 100;
+  console.log(`✓ wrote ${OUT_PATH}`);
+  console.log(`  ${total} masters total`);
+  console.log(`  ${portraits} portraits (${portraitPct.toFixed(1)}%)`);
+  console.log(`  ${placeholders} name-card placeholders`);
+  console.log(`  ${none} masters with no media_asset`);
+  console.log(`  cited media coverage: ${cited}/${total} (${pct.toFixed(1)}%)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #14.

- Adds `scripts/image-coverage-audit.ts` and the committed
  `scripts/image-coverage-audit.csv` — one row per master (415 rows)
  with `slug, name, school, birth/death year, era, coverage,
  storage_path, source, license, citation_source, notes`. Coverage is
  one of `portrait | placeholder | none` so the placeholder gap that
  remains for ~240 masters is auditable instead of silent.
- Extends `scripts/check-exit-criteria.ts` with a configurable image-
  coverage gate (`IMAGE_COVERAGE_THRESHOLD`, default 95%). When fewer
  than the threshold of masters carry a cited `media_asset`, the audit
  prints the offending slugs and exits non-zero so CI stops the
  regression. Current coverage is 100% (415/415).

## Notes

- No new unsupervised Wikimedia Commons fetches — the audit only
  reports on what's already in the database.
- The 240 `placeholder` rows are the existing per-school enso
  name-card SVGs generated by `scripts/generate-name-placeholders.ts`,
  which are the issue's "deliberate no-portrait fallback".

## Test plan

- [x] `DATABASE_URL=file:zen.db npx tsx scripts/image-coverage-audit.ts` writes 415-row CSV
- [x] `DATABASE_URL=file:zen.db npx tsx scripts/check-exit-criteria.ts` exits 0 with 100% coverage
- [x] Simulated regression (deleted 30 media_asset citations): gate exits 1 and lists the missing slugs
- [x] `npx eslint scripts/image-coverage-audit.ts scripts/check-exit-criteria.ts` clean