### PR TITLE
proverbs: expand collection to 490 with balanced regional distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "DATABASE_URL=file:zen.db tsx scripts/seed-db.ts && DATABASE_URL=file:zen.db tsx scripts/seed-korean-vietnamese.ts && DATABASE_URL=file:zen.db tsx scripts/seed-maezumi-lineage.ts && DATABASE_URL=file:zen.db tsx scripts/seed-temples.ts && DATABASE_URL=file:zen.db tsx scripts/seed-deshimaru-lineage.ts && DATABASE_URL=file:zen.db tsx scripts/backfill-ingestion-metadata.ts && DATABASE_URL=file:zen.db tsx scripts/register-disk-images.ts && DATABASE_URL=file:zen.db tsx scripts/fetch-kv-images.ts && DATABASE_URL=file:zen.db tsx scripts/generate-thumbnails.ts && DATABASE_URL=file:zen.db tsx scripts/generate-name-placeholders.ts && DATABASE_URL=file:zen.db tsx scripts/generate-static-data.ts && DATABASE_URL=file:zen.db tsx scripts/generate-llms-full.ts",
+    "prebuild": "DATABASE_URL=file:zen.db tsx scripts/seed-db.ts && DATABASE_URL=file:zen.db tsx scripts/seed-korean-vietnamese.ts && DATABASE_URL=file:zen.db tsx scripts/seed-maezumi-lineage.ts && DATABASE_URL=file:zen.db tsx scripts/seed-temples.ts && DATABASE_URL=file:zen.db tsx scripts/seed-deshimaru-lineage.ts && DATABASE_URL=file:zen.db tsx scripts/seed-curated-proverbs.ts && DATABASE_URL=file:zen.db tsx scripts/backfill-ingestion-metadata.ts && DATABASE_URL=file:zen.db tsx scripts/register-disk-images.ts && DATABASE_URL=file:zen.db tsx scripts/fetch-kv-images.ts && DATABASE_URL=file:zen.db tsx scripts/generate-thumbnails.ts && DATABASE_URL=file:zen.db tsx scripts/generate-name-placeholders.ts && DATABASE_URL=file:zen.db tsx scripts/generate-static-data.ts && DATABASE_URL=file:zen.db tsx scripts/generate-llms-full.ts",
     "build": "DATABASE_URL=file:zen.db next build",
     "start": "next start",
     "lint": "eslint .",
@@ -23,6 +23,7 @@
     "thumbnails": "tsx scripts/generate-thumbnails.ts",
     "seed:kv": "DATABASE_URL=file:zen.db tsx scripts/seed-korean-vietnamese.ts",
     "seed:proverbs": "DATABASE_URL=file:zen.db tsx scripts/seed-curated-proverbs.ts",
+    "report:proverbs": "DATABASE_URL=file:zen.db tsx scripts/report-proverb-coverage.ts",
     "seed:names": "DATABASE_URL=file:zen.db tsx scripts/seed-native-names-fill.ts",
     "seed:maezumi": "DATABASE_URL=file:zen.db tsx scripts/seed-maezumi-lineage.ts",
     "seed:deshimaru": "DATABASE_URL=file:zen.db tsx scripts/seed-deshimaru-lineage.ts",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5741,308 +5741,264 @@ Plus and minus—they are one activity. When you truly understand this, you are 
 
 ### Landscape of Spring
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 In the landscape of spring, there is neither better nor worse. The flowering branches grow naturally, some long, some short.
 
 ### Entering the Forest
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Entering the forest, he does not disturb a blade of grass. Entering the water, he does not cause a ripple.
 
 ### Bamboo Shadows
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The bamboo shadows sweep the stairs, but no dust is stirred.
 
 ### Scoop Up Water
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Scoop up water and the moon is in your hands. Handle flowers and their fragrance fills your clothes.
 
 ### Wild Geese Reflection
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The wild geese do not intend to cast their reflection. The water has no mind to receive their image.
 
 ### A Thousand Mountains
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 A thousand mountains—not a bird in flight. Ten thousand paths—no trace of man.
 
 ### Ride Your Horse
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Ride your horse along the edge of a sword. Hide yourself in the middle of flames.
 
 ### Cast Off What Has Been Realized
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Cast off what has been realized. Turn back to the subject that realizes.
 
 ### Blue Mountains
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The blue mountains are of themselves blue mountains. White clouds are of themselves white clouds.
 
 ### Dense Bamboo Forest
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Though the bamboo forest is dense, water flows through it freely.
 
 ### From the Withered Tree
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 From the withered tree, a flower blooms.
 
 ### Knock on the Sky
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Knock on the sky and listen to the sound.
 
 ### A Single Leaf Falls
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 A single leaf falls—all under heaven know it is autumn.
 
 ### Clear Water
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Clear water all the way to the bottom. A fish swims like a fish.
 
 ### Atop the Hundred-Foot Pole
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Atop the hundred-foot pole, how do you step forward?
 
 ### Iron Tree Blooms
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 When the iron tree blooms, the rooster lays an egg.
 
 ### The Moon Does Not Think
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The moon does not think about being reflected, nor does the water think about reflecting it.
 
 ### Put Your Heart at Rest
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Put your heart at rest. Do not look for anything outside of this.
 
 ### Fall Seven Times
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Fall seven times, stand up eight.
 
 ### The Frog in the Well
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The frog in the well knows nothing of the great ocean.
 
 ### The Reverse Side
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The reverse side also has a reverse side.
 
 ### Sitting Quietly, Not Waiting
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Sitting quietly, doing nothing—not even waiting.
 
 ### All Know the Way
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 All know the Way, but few actually walk it.
 
 ### The Thief Left It Behind
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The thief left it behind—the moon at the window.
 
 ### A Sheet of Paper
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Even a sheet of paper has two sides.
 
 ### Moon on the River
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The moon shines on the river. The wind blows through the pines.
 
 ### Snow on the Plum Tree
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The snow on the plum tree is not yet melted, but already the branches bloom.
 
 ### When the Student Is Ready
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 When the student is ready, the teacher will appear. When the student is truly ready, the teacher will disappear.
 
 ### Before the Bell Rings
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Before the bell rings, where is the sound? After the bell rings, where does it go?
 
 ### The Great Path Has No Gate
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The great path has no gate. A thousand roads enter it.
 
 ### Drink Your Tea Slowly
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Drink your tea slowly and reverently, as if it is the axis on which the whole earth revolves.
 
 ### The River Flows to the Sea
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 No matter how hard the wind blows, the river always flows to the sea.
 
 ### The Vast Inane
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 In the vast inane there is no back or front. The path of the bird annihilates east and west.
 
 ### From the Withered Stump
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 From the withered stump, a dragon emerges.
 
 ### Return to the Root
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 To return to the root is to find the meaning. To chase appearances is to miss the source.
 
 ### Not Twice This Day
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Not twice this day.
 
 ### An Inch of Time
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 An inch of time is an inch of gold, but you cannot buy an inch of time with an inch of gold.
 
 ### Move and the Way Will Open
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Move and the way will open.
 
 ### The Spring Rain
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The spring rain soaks everything equally—the beautiful garden and the empty lot.
 
 ### Clouds Come and Go
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Clouds come and go. Behind them, the sun has never moved.
 
 ### A Person Who Drinks Water
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 A person who drinks water knows for themselves whether it is hot or cold.
 
 ### The Arrow Has Left the Bow
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The arrow has left the bow. It will not return.
 
 ### The Lotus in Muddy Water
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 The lotus grows in the muddy water. Without the mud, there is no lotus.
 
 ### Plunge into the Poison
 
-- **Attribution:** Shakyamuni Buddha
 - **Type:** proverb
 
 Plunge into the poison to discover the antidote.
@@ -6159,12 +6115,12 @@ Do not think you will necessarily be aware of your own enlightenment.
 
 Continuous practice, day after day, is the most appropriate way of expressing gratitude.
 
-### Flowers Fall
+### Flowers Fall, Weeds Spring
 
 - **Attribution:** Dogen
 - **Type:** proverb
 
-Flowers fall amid our longing, and weeds spring up amid our antipathy.
+Flowers fall amid our longing; weeds spring up amid our aversion. Both belong to the same garden, and the garden does not consult us about its arrangement.
 
 ### Your Original Face
 
@@ -8063,3 +8019,2572 @@ Panshan said, "Too late."
 A monk asked Baling, "What is the school of Yunmen?"
 
 Baling said, "A silver bowl filled with snow."
+
+### The Mind Is Buddha
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+Outside of this mind there is no Buddha. Outside of this nature there is no dharma. Look for Buddha apart from your own mind, and you will not find him in a thousand kalpas.
+
+### Sudden Awakening, Gradual Cultivation
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+Though one has awakened all at once to the same nature as the Buddhas, beginningless habit-energies remain; and so practice must still gradually purify what awakening has already seen.
+
+### Tracing Back the Radiance
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+Trace back the radiance of your own mind. Do not chase after it outside — there is nothing outside to find.
+
+### What Is This?
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+Take up the phrase and hold it with great doubt — as if you had swallowed a red-hot iron ball and can neither vomit it out nor swallow it down. When the doubt mass breaks, that is your real face.
+
+### Silence Speaks the Dharma
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+The sound of the stream in the night valley — that voice has been preaching for thousands of years, and no one has yet heard the end of its sermon.
+
+### Hold the Phrase Like a Mosquito Biting Iron
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+Work on the critical phrase as a mosquito works on an iron ox — at a point where it cannot sting, let it bore in with its whole body. In one instant, body and life fall away together.
+
+### Do Not Be Deceived
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+When an awakening is genuine, it is complete of itself — nothing remains to be accumulated. Do not be deceived by a clear moment and call it the path. Walk the path until the path itself can be set down.
+
+### Only Don't Know
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+Before thinking, what are you? Keep that question. Don't know — that mind is clear like space. In the don't-know, all beings are already saved.
+
+### Knowing the Mind, Seeing the Nature
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+Buddha is not somewhere else. Go back into your own mind and see clearly — there the Buddha has been waiting all along. Search outside, and you will run to exhaustion and not arrive.
+
+### Living Carefree According to Conditions
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+When hungry, eat. When tired, rest. When things come, respond. When they go, let them pass. The Way is not rare — only the willingness to meet it plainly.
+
+### One Breath
+
+- **Attribution:** Liễu Quán
+- **Type:** proverb
+
+In one breath, a student of the Way lives and dies a thousand times. The teacher who stays with that breath, neither grasping nor pushing it away, has nothing more to teach.
+
+### The Mind-Seal Has No Form
+
+- **Attribution:** Vinītaruci
+- **Type:** proverb
+
+The mind-seal has no form, yet it is not hidden. It is nearer than your own hand, yet it cannot be grasped. Hand it on and it is not diminished; receive it and it is not increased.
+
+### The Present Moment
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+The present moment is the only moment available to us, and it is the door to all moments. When you touch the present deeply, you touch the past and the future at the same place.
+
+### Interbeing
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+If you are a poet, you will see clearly that there is a cloud floating in this sheet of paper. Without a cloud, there will be no rain; without rain, the trees cannot grow; and without trees, we cannot make paper. The cloud and the paper inter-are.
+
+### Wordless
+
+- **Attribution:** Vô Ngôn Thông
+- **Type:** proverb
+
+The one who speaks the dharma most completely has not opened his mouth. The student who hears it most clearly has not pricked up his ears.
+
+### One Mind, Nothing Else
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+All the Buddhas and all sentient beings are nothing but the One Mind — there is no other dharma. This mind has been there from the beginning. It is not born and does not die.
+
+### This Very Mind Is Buddha
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+This very mind is Buddha. When someone asks for the teaching outside this mind, he is like a man riding an ox looking for an ox.
+
+### Host Within Host
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+When the host sees the guest, that is still a division. When the host sees the host, the whole household falls silent.
+
+### The Gateless Barrier
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+The Great Way has no gate — a thousand paths enter it. Once you pass through the barrier, you walk freely between heaven and earth.
+
+### The Undivided Field
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+A single phrase can block off ten thousand gates. A single glance can open the whole field. Where is the one not yet divided? Answer before you open your mouth.
+
+### Practice Is Realization
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+To study the Buddha Way is to study the self. To study the self is to forget the self. To forget the self is to be verified by the ten thousand dharmas.
+
+### The Unborn Buddha-Mind
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+Your mind, as you were born with it, is the Unborn buddha-mind — marvelously illuminating, unmistaken. Simply not making anything of it, you abide where everything is complete.
+
+### All Beings Are Originally Buddha
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+All beings are originally Buddha, as water and ice — apart from water no ice, apart from beings no Buddha. How sad that beings seek afar and do not know what is at hand.
+
+### Flower and Smile
+
+- **Attribution:** Mahakashyapa
+- **Type:** proverb
+
+On Vulture Peak the World-Honored One held up a flower; the assembly was silent; only Mahākāśyapa smiled. The flower has not stopped being held up; the smile has not stopped traveling.
+
+### Why Mahākāśyapa Smiled
+
+- **Attribution:** Mahakashyapa
+- **Type:** proverb
+
+He smiled not because he understood, but because there was nothing left to misunderstand. To smile in that way once is to have transmission already.
+
+### Three Robes and a Bowl
+
+- **Attribution:** Mahakashyapa
+- **Type:** proverb
+
+Three robes and a bowl are enough for a monk. If you cannot live within those four objects, no fifth object will save you.
+
+### Ascetic Discipline
+
+- **Attribution:** Mahakashyapa
+- **Type:** proverb
+
+Some called my discipline severe. I never asked the body for more than the body could give; I asked it not to bargain. The bargaining is the only severe thing.
+
+### First Council
+
+- **Attribution:** Mahakashyapa
+- **Type:** proverb
+
+After the World-Honored One died, we gathered to remember his words. Memory was the first sangha; the rules were a fence around the memory; the practice was the field inside the fence.
+
+### Thus Have I Heard
+
+- **Attribution:** Ananda
+- **Type:** proverb
+
+Every sutra begins: thus have I heard. I was the one who heard. Memory is the first ferry; do not curse the ferryman.
+
+### Women as Equals
+
+- **Attribution:** Ananda
+- **Type:** proverb
+
+I asked the World-Honored One whether women could awaken as men do. He said: yes. I asked again, in case he had not heard me. He said: yes again. The dharma did not need a third asking — but the world did.
+
+### Knock Down the Pole
+
+- **Attribution:** Ananda
+- **Type:** proverb
+
+Mahākāśyapa told me: knock down the pole at the gate. I did so, and only then was I admitted to the council. The robe and the memorizing were not enough; the gate too had to be released.
+
+### Twenty-Five Years as Attendant
+
+- **Attribution:** Ananda
+- **Type:** proverb
+
+I was the World-Honored One's attendant for twenty-five years. The dharma I learned was not in the talks I overheard; it was in the way the bowl was washed after each meal.
+
+### Late Arahantship
+
+- **Attribution:** Ananda
+- **Type:** proverb
+
+I attained arahantship the night before the council, after years of being told I was not yet ready. Whoever has been told he is not ready: that telling itself is the door.
+
+### Emptiness Is the Medicine
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+If you grasp emptiness as a thing, the medicine becomes a sickness. The Buddha gave emptiness as the medicine for all views; do not let it become another view.
+
+### Two Truths
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+There is conventional truth and there is ultimate truth. Without the conventional, the ultimate cannot be taught; without the ultimate, the conventional becomes a prison. Walk on both feet.
+
+### Eight Negations
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+No arising, no ceasing; no permanence, no annihilation; no coming, no going; no one, no many. From this eightfold no, the world arises freshly each instant.
+
+### Snake and Rope
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+In the dim light, the rope looked like a snake. Once the lamp was brought, neither the snake nor the rope was as you had supposed. Bring the lamp, and your problems re-introduce themselves.
+
+### Friendly Letter to a King
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+I wrote to a king: rule with patience as if the kingdom were your own body, and not as if your body were the kingdom. The king who confuses these orders ends up wounded by his own taxes.
+
+### Without a Thesis of My Own
+
+- **Attribution:** Nagarjuna
+- **Type:** proverb
+
+I have no thesis of my own. I take up your thesis, follow it through, and let it dissolve at its own end. Whoever calls me a teacher of nothing has heard me correctly.
+
+### Thirty Verses on Consciousness
+
+- **Attribution:** Vasubandhu
+- **Type:** proverb
+
+Mind makes the world; the world makes the mind. Stand at the seam of these two, and the whole loom shows itself.
+
+### Changed His Mind
+
+- **Attribution:** Vasubandhu
+- **Type:** proverb
+
+I taught the doctrine of one school for thirty years and then changed my mind. The students who refused to change with me lost more than I did.
+
+### Storehouse Consciousness
+
+- **Attribution:** Vasubandhu
+- **Type:** proverb
+
+The seeds of all your acts are stored in a hidden room of the mind. Each act planted today is a fruit you will eat tomorrow — be careful what you sow even when no one is looking.
+
+### Three Natures
+
+- **Attribution:** Vasubandhu
+- **Type:** proverb
+
+The imagined, the dependent, the perfected — three natures of one experience. The imagined hides the dependent; the dependent hides the perfected; remove the imagined, and the rest is already shining.
+
+### Life of the Buddha
+
+- **Attribution:** Ashvaghosha
+- **Type:** proverb
+
+I wrote the life of the Buddha as a poet. Whoever reads only the doctrine misses the body of the man who carried it; whoever reads only the man misses the doctrine he carried.
+
+### Awakening of Faith
+
+- **Attribution:** Ashvaghosha
+- **Type:** proverb
+
+Faith is not belief in a thing; faith is the willingness to keep sitting when the belief in sitting has gone. The dharma waits for the second kind.
+
+### Poet and Monk
+
+- **Attribution:** Ashvaghosha
+- **Type:** proverb
+
+The poet hopes for a perfect verse and grieves the imperfect one. The monk practices the imperfect verse and lets the perfect one go.
+
+### Four Hundred Stanzas
+
+- **Attribution:** Aryadeva
+- **Type:** proverb
+
+First I refute the wrong views; then I plant the right; then I let go of the right view too. Without the third step, the second is just another wrong view in disguise.
+
+### Debate Without Pride
+
+- **Attribution:** Aryadeva
+- **Type:** proverb
+
+Win the debate, and the dharma loses. Lose the debate, and the dharma loses. Sit in the debate without preference, and the dharma stands up at the end and walks home.
+
+### Clear Water Holds the Sky
+
+- **Attribution:** Aryadeva
+- **Type:** proverb
+
+Clear water holds the sky without effort. Stir it, and the sky breaks into pieces. Practice is the not-stirring.
+
+### No Need to Recite
+
+- **Attribution:** Prajnatara
+- **Type:** proverb
+
+Other monks recited the sutras at the donor's house; I sat. The donor asked: why do you not recite? I answered: when I breathe in, I do not consort with the world of beings; when I breathe out, I do not consort with the world of senses. So am I always reciting the sutra of all the buddhas.
+
+### Send Bodhidharma North
+
+- **Attribution:** Prajnatara
+- **Type:** proverb
+
+Sixty years after I am gone, you will go to a country to the north. Do not stay in our temple; the dharma in this place is well kept and needs no more keeping. The country to the north needs you more than we do.
+
+### No Pride of Lineage
+
+- **Attribution:** Prajnatara
+- **Type:** proverb
+
+I am the twenty-seventh patriarch only because someone wrote it down. The number does not bow when I bow; it does not eat when I eat; it has nothing to do with the sitting.
+
+### Walk, Do Not Talk
+
+- **Attribution:** Punyamitra
+- **Type:** proverb
+
+I walked a long way for this dharma; I do not propose to talk it back into a cage. Whoever wants to know what I know should walk too.
+
+### Old Age Teaches by Itself
+
+- **Attribution:** Punyamitra
+- **Type:** proverb
+
+Old age teaches by itself if you let it. Do not race against your wrinkles; let them be the third teacher in the room, after your master and your hut.
+
+### Do Not Pity Yourself
+
+- **Attribution:** Punyamitra
+- **Type:** proverb
+
+Self-pity is the sickness that disguises itself as the cure. Cut it cleanly; you will be surprised how light the body becomes when you are no longer carrying yourself.
+
+### Find the Old King
+
+- **Attribution:** Buddhamitra
+- **Type:** proverb
+
+I told my disciple: there is a son of an old king walking in the marketplace, and he does not yet know who he is. Find him; remind him; and the kingdom is reset by a single sentence.
+
+### Old and Young
+
+- **Attribution:** Buddhamitra
+- **Type:** proverb
+
+An old monk and a young monk study the same dharma differently. The old monk has less time; the young monk has less hurry. Both must learn the other's gift.
+
+### Counted Stones
+
+- **Attribution:** Upagupta
+- **Type:** proverb
+
+I asked each new student to bring a small stone for every passion that arose. The cave filled with stones; the passions did not. Then we built a wall around the cave with the stones, and used it as a meditation hall.
+
+### Lay Merchant Awakens
+
+- **Attribution:** Upagupta
+- **Type:** proverb
+
+A wealthy merchant came to me wanting to leave the world. I told him: stay in the world and trade fairly; the dharma is in the weighing of the goods. He returned a year later and said: the scales have been my master.
+
+### No Merit
+
+- **Attribution:** Puti Damo
+- **Type:** proverb
+
+Emperor Wu asked: how much merit have I gained from building temples? I said: no merit. Real virtue does not count itself; the moment you keep score, you have walked out of it.
+
+### Vast Emptiness, Nothing Holy
+
+- **Attribution:** Puti Damo
+- **Type:** proverb
+
+He asked: what is the highest meaning of the holy truth? I answered: vast emptiness, nothing holy. He could not understand. I crossed the river and went north.
+
+### Bring Me Your Mind
+
+- **Attribution:** Puti Damo
+- **Type:** proverb
+
+Huike said: my mind is not at peace. I said: bring me your mind, and I will pacify it. He searched and could not find it. I said: there — I have pacified it for you.
+
+### Skin, Flesh, Bone, Marrow
+
+- **Attribution:** Puti Damo
+- **Type:** proverb
+
+I told my four students each to speak the Way. Daofu received my skin. Zongchi received my flesh. Daoyu received my bone. Huike received my marrow. The four divisions were one body; the dharma is whole even when described in pieces.
+
+### There Is No Mirror Stand
+
+- **Attribution:** Dajian Huineng
+- **Type:** proverb
+
+Originally there is not a single thing — where could dust alight? Polish a mirror that is not there, and you make new dust by polishing.
+
+### Self-Nature Suffices
+
+- **Attribution:** Dajian Huineng
+- **Type:** proverb
+
+How marvelous: self-nature is originally pure. How marvelous: self-nature is originally unborn. How marvelous: self-nature is originally complete. How marvelous: self-nature is originally unmoving. How marvelous: from self-nature, the ten thousand things arise.
+
+### Without Thinking Good or Evil
+
+- **Attribution:** Dajian Huineng
+- **Type:** proverb
+
+Without thinking good or evil, what is your original face — the face you had before your father and mother were born?
+
+### An Illiterate Patriarch
+
+- **Attribution:** Dajian Huineng
+- **Type:** proverb
+
+I cannot read the sutra you hold; please read it aloud. The sutra is not in the words on the paper. It rises only in the place where listening is empty enough to receive.
+
+### Not the Flag, Not the Wind
+
+- **Attribution:** Dajian Huineng
+- **Type:** proverb
+
+Two monks argued: one said the flag moves, the other said the wind moves. I said: it is not the flag and not the wind — it is your minds that move.
+
+### Not Difficult
+
+- **Attribution:** Jianzhi Sengcan
+- **Type:** proverb
+
+The Great Way is not difficult for those who hold no preferences. When love and hate are both absent, everything stands forth, transparent and undisguised.
+
+### The Tiniest Distinction
+
+- **Attribution:** Jianzhi Sengcan
+- **Type:** proverb
+
+Make the slightest distinction, and heaven and earth are set infinitely apart. Drop the distinction, and they meet in the palm of your hand.
+
+### Do Not Search for the Truth
+
+- **Attribution:** Jianzhi Sengcan
+- **Type:** proverb
+
+Do not search for the truth — only cease to cherish opinions. The truth has been waiting in your kitchen the whole time.
+
+### Guard the One Mind
+
+- **Attribution:** Daman Hongren
+- **Type:** proverb
+
+Guard the one mind through all twelve hours of the day. The chickens scatter, the visitors come and go; if the one mind is guarded, none of them disturb the household.
+
+### True Pearl in Muddy Water
+
+- **Attribution:** Daman Hongren
+- **Type:** proverb
+
+Stir the muddy water and the pearl is hidden. Sit still, and the mud settles, and the pearl appears — not because you have created it but because you have stopped disturbing it.
+
+### Two Verses, One Field
+
+- **Attribution:** Daman Hongren
+- **Type:** proverb
+
+Shenxiu wrote of polishing the mirror. Huineng wrote that there is no mirror. The robe went south; the polishing did not stop. Both verses were correct, in different rooms of the same house.
+
+### Mountains Are Mountains Again
+
+- **Attribution:** Qingyuan Xingsi
+- **Type:** proverb
+
+Before I studied Chan, mountains were mountains and rivers were rivers. After studying Chan, mountains were no longer mountains and rivers no longer rivers. Now, after thirty years, mountains are again mountains and rivers again rivers — but with fewer feet of mine in the way.
+
+### Cutting an Axe-Handle
+
+- **Attribution:** Qingyuan Xingsi
+- **Type:** proverb
+
+To cut an axe-handle, the model is in your hand. To pass on the dharma, the model is in your life. Look closely at the model; if it has a chip in it, the new handle will too.
+
+### No Marvels at the Hermitage
+
+- **Attribution:** Qingyuan Xingsi
+- **Type:** proverb
+
+There are no marvels at this hermitage. We sweep, we cook, we sit. If you wanted marvels, you should have gone to the city — they sell them cheap there, and they break before you reach home.
+
+### Sound of Grass
+
+- **Attribution:** Qingyuan Xingsi
+- **Type:** proverb
+
+If you cannot hear the sound of grass growing, you are not yet quiet enough. Sit until you hear it, and you will not be tempted to mistake your speech for teaching.
+
+### Polishing a Tile
+
+- **Attribution:** Nanyue Huairang
+- **Type:** proverb
+
+I polished a tile in front of him until he asked what I was doing. I said: making a mirror. He laughed: a tile cannot be polished into a mirror. I said: nor can sitting be polished into a Buddha — if you are sitting in order to become one.
+
+### Cart or Ox?
+
+- **Attribution:** Nanyue Huairang
+- **Type:** proverb
+
+If a cart is stuck, do you whip the cart or the ox? If you sit in order to make the body still and the mind goes on as before, you have whipped the cart and not the ox.
+
+### Eight Years to Speak
+
+- **Attribution:** Nanyue Huairang
+- **Type:** proverb
+
+Mazu studied with me for eight years before I asked him a single question. The answer that came was already an old answer when it came. The eight years had not been spent on a question — they had been spent on the mouth.
+
+### Ordinary Mind Is the Way
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+What is the Way? Ordinary mind is the Way. What is ordinary mind? Hungry, eat. Tired, sleep. Foolishness arises only when we add anything else.
+
+### A Shout That Deafens
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+I shouted at Baizhang, and his ears rang for three days. The shout was not punishment — it was the doorway. Three days of deafness is a small price for the silence that follows.
+
+### Not Mind, Not Buddha
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+Yesterday I said: this very mind is Buddha. Today I say: not mind, not Buddha. The teaching shifts; the student who clings to either statement misses both.
+
+### Trample the Buddha
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+When you walk through the gate, leave the Buddha outside. If you carry him in, he becomes a stone in your shoe.
+
+### Eighty-Four Students
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+I had eighty-four enlightened students, and not one of them taught the same thing. The dharma is wide enough to give each of them a different door, and narrow enough that all those doors open onto the same yard.
+
+### Wild Fox
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+If you say a great practitioner does not fall under cause and effect, you become a wild fox for five hundred lives. If you say he is not blind to cause and effect, the wild fox is freed at once. Watch the difference of one syllable.
+
+### The Tile and the Tile-Maker
+
+- **Attribution:** Mazu Daoyi
+- **Type:** proverb
+
+Nanyue polished a tile to make a mirror; I polished sitting to make a Buddha. He laughed; I laughed back. From that day, I sat for the sake of sitting, and a Buddha appeared without anyone making one.
+
+### A Day Without Work
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+A day without work is a day without food. When my disciples hid my tools, I sat at the table and pushed the bowl away. They returned the tools the next morning.
+
+### The Pure Rule
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+I wrote down the rules of the monastery so that no master after me could be tempted to make himself a king. Read the rules; they will outlast my voice. The voice was only there to write them.
+
+### Hoe and Sutra Together
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+Bring the sutra to the field, and the field to the sutra. The two were never apart; only our habits make them seem so.
+
+### Three Pounds of Flax
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+What is Buddha? Three pounds of flax. The student who finds this strange has not yet weighed his own questions.
+
+### Fox in the Audience
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+An old man came to my talks for many years, sitting at the back. He told me he had been a wild fox for five hundred lives because of one wrong word. We buried the fox with monks' rites. The wrong word, properly answered, frees not only the answerer.
+
+### Step Out of the Doorway
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+Stand in the doorway and the wind cannot enter. Step into the room and the wind cannot enter. Step out, and the room and the wind both pass through you.
+
+### What Is Extraordinary
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+What is extraordinary? Sitting alone on the great peak. The peak does not feel extraordinary about itself; that is its secret.
+
+### Wash Your Bowl
+
+- **Attribution:** Baizhang Huaihai
+- **Type:** proverb
+
+After breakfast, what should I do? Wash your bowl. After washing the bowl, what should I do? Set it down. After setting it down, what should I do? You are already doing it.
+
+### Mind Is Empty Like Space
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+The mind is like empty space — and yet it is full of every star. To find the stars, you do not need to leave the space; only to stop looking elsewhere.
+
+### Beyond the Mind, No Buddha
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+There is no Buddha outside the mind. To search for a Buddha is to lose your Buddha. The search itself is the only thing in the way.
+
+### Cold Pierces the Bone
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+If the cold did not pierce the bone, how would the plum blossom be so fragrant? Practice without difficulty is fragrance without flower.
+
+### Striking the Emperor
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+When the future emperor questioned me sloppily, I struck him with my staff. He went on to rule the empire; he never asked a sloppy question again. The staff has many jobs.
+
+### No Grades Among Buddhas
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+There are no grades among Buddhas; you are not closer or farther by years of sitting. The day you forget the question of distance, you have arrived.
+
+### Give Up Words and Reach Beyond
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+Give up words, give up thinking, and stretch out to the place where words and thinking cannot reach. There you will meet me — not as a teacher, but as the same hand you use to hold this cup.
+
+### Six Realms, One Mind
+
+- **Attribution:** Huangbo Xiyun
+- **Type:** proverb
+
+Heaven, hell, animal, hungry ghost, human, demigod — six realms, one mind. The mind that wakes from one to the next is the same mind in different clothes.
+
+### The True Person of No Rank
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+There is a true person of no rank, always coming in and going out through the gate of the senses. Those who have not yet seen this person — look! Look!
+
+### Kill the Buddha, Kill the Patriarchs
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+If you meet the Buddha on the road, kill the Buddha. If you meet a patriarch, kill the patriarch. Only by killing the images that walk in front of you do you free the original face that has been walking with you all along.
+
+### Four Kinds of Shout
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+Sometimes I shout like a king's sword. Sometimes like a lion crouching. Sometimes like a fishing pole probing the waters. Sometimes a shout that is not a shout. The student who learns to tell them apart is already half-free.
+
+### Four Relations of Host and Guest
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+Sometimes the host examines the guest, sometimes the guest examines the host, sometimes guest and host examine each other, sometimes host and guest forget themselves. Be all four; do not become attached to any of them.
+
+### Do Not Borrow Eyes
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+Do not borrow the patriarchs' eyes. The eyes you have are already the patriarchs' eyes; the borrowing is what makes them seem someone else's.
+
+### Three Mysterious Gates
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+In one phrase, three mysterious gates. In one mysterious gate, three essentials. In one essential, ten thousand returns. The student who insists on counting them does not pass through any of them.
+
+### Followers of the Way
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+Followers of the Way: do not let yourself be turned by circumstances. Wherever you are, simply be the host. Then circumstances cannot help being true.
+
+### No Affair to Take Up
+
+- **Attribution:** Linji Yixuan
+- **Type:** proverb
+
+When there is no affair to take up, do not take one up. When there is one, take it up without leaning on it. Then your day's work and your day's idleness are equally Buddha-work.
+
+### Mu
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+Does a dog have Buddha-nature? Mu. Three years on this one syllable, and the syllable will pour back through your life and rinse it clean.
+
+### Have You Eaten? Wash Your Bowl
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+A monk said: I have just entered the monastery; please instruct me. Have you eaten breakfast? Yes. Then go and wash your bowl. The monk woke up.
+
+### Cypress Tree in the Garden
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+What is the meaning of the patriarch's coming from the west? The cypress tree in the garden. Do not look elsewhere — there is no elsewhere.
+
+### Have a Cup of Tea
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+A new monk arrived; I told him to have a cup of tea. An old monk arrived; I told him to have a cup of tea. The temple steward asked: why the same answer? I told him to have a cup of tea.
+
+### Three Pounds, One Mountain
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+Some teacher said: three pounds of flax. Some teacher said: a dry shit-stick. I say: a stone bridge. Cross all three, and you arrive at the same village.
+
+### Even Now, Not Yet
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+I am eighty years old, and even now I have not finished my study. The day I finish, I will sit down and rest; until then, the work continues whether or not I am tired.
+
+### The Stone Bridge
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+I have heard about the famous stone bridge of Zhaozhou — but I see only a single log. The stone bridge crosses both donkeys and horses; the single log only crosses you.
+
+### Old Buddha, Old Cup
+
+- **Attribution:** Zhaozhou Congshen
+- **Type:** proverb
+
+What is Zhaozhou? An old Buddha. What is the old Buddha? An old cup. The cup is not less because it is old; tea fills it as it always did.
+
+### Song of the Grass Hut
+
+- **Attribution:** Shitou Xiqian
+- **Type:** proverb
+
+I have built a grass hut in which there is nothing of value. After eating, I'm ready for a nap. When the world looks for me, I'm not here — though I never went anywhere.
+
+### Merging of Difference and Sameness
+
+- **Attribution:** Shitou Xiqian
+- **Type:** proverb
+
+Brightness and darkness are like the front and back foot in walking. The light is not above the dark; both are needed for the next step.
+
+### Stone Head
+
+- **Attribution:** Shitou Xiqian
+- **Type:** proverb
+
+They call me Stone Head. A stone has no opinion of itself, no preference for sun or rain, no plan for tomorrow. If only my students were as steady.
+
+### Do Not Think About the Roof
+
+- **Attribution:** Shitou Xiqian
+- **Type:** proverb
+
+When sitting in your hut, do not think about whether the roof will leak. If it leaks, you will know. The thought beforehand only takes the place of the seat.
+
+### Trickle and River
+
+- **Attribution:** Shitou Xiqian
+- **Type:** proverb
+
+A trickle and a great river — the trickle does not envy the river, the river does not despise the trickle. Both flow downhill toward the same sea.
+
+### Five Ranks of Lord and Vassal
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+There is the apparent within the real; the real within the apparent; coming from within the real; arriving in mutual integration; arrival in unity. Five ranks, one lord — the names change, the lord does not.
+
+### Where Cold Cannot Reach
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+A monk asked: when cold and heat come, how can we escape them? Why not go to a place where there is no cold and no heat? Where is such a place? Where the cold kills you, the heat kills you.
+
+### Seeing My Reflection in the Stream
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+Crossing the stream I saw my own face in the water — and there it was at last, looking back. He is exactly me, but I am not him; the meeting is the meaning.
+
+### Not a Stranger
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+If you go to find this person, you will fail; the going makes him a stranger. Sit still where you are; soon he will sit down across from you, and you will not be able to tell which is the host.
+
+### Snow Falls into the Silver Bowl
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+Snow falls into a silver bowl: the white touches the white, and yet it is two. So with the meeting of the apparent and the real — they are not one, and not two, and not somewhere in between.
+
+### Last Sickness
+
+- **Attribution:** Dongshan Liangjie
+- **Type:** proverb
+
+Even a sickness can be the teaching. When my last sickness came, my students wept. I said: this body is not yours to mourn. Mourn the day you cannot tell whose body it is.
+
+### Wine of Jade
+
+- **Attribution:** Caoshan Benji
+- **Type:** proverb
+
+There is a wine of jade in this house — invisible, scentless, intoxicating. The student who reaches for the cup misses it; the student who simply sits at the table is already drinking.
+
+### Loyal Vassal
+
+- **Attribution:** Caoshan Benji
+- **Type:** proverb
+
+A loyal vassal speaks bluntly, even to the lord. So a real student answers his master plainly — the loyalty is in the bluntness, not in the bow.
+
+### Painting the Five Positions
+
+- **Attribution:** Caoshan Benji
+- **Type:** proverb
+
+I drew circles for the five positions, partly black, partly white. A picture is only paint; the positions are in the way you stand up from the cushion.
+
+### Blind Donkey
+
+- **Attribution:** Caoshan Benji
+- **Type:** proverb
+
+Beware of being a blind donkey, dragged by the lead. The lead is your own habit, dressed up as the dharma. Cut it, and the road is yours.
+
+### Dry Shit-Stick
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+What is Buddha? A dry shit-stick. The blunt phrase is the medicine for the polished mind.
+
+### Every Day Is a Good Day
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+What about before the fifteenth of the month? I will not ask. After the fifteenth? Every day is a good day. The good is not in the calendar but in the willingness to meet whatever shows up.
+
+### One-Word Barrier
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+What is the dharma? Suitable. What is the practice? Through. What is the highest matter? Look. One word, one barrier; pass it, and you walk.
+
+### Three Statements of Yunmen
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+A statement that meets heaven and earth; a statement that follows the waves; a statement that cuts off all streams. Use them in turn — never as a formula, always as a fit.
+
+### Bell and Robe
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+When the bell rings, why do you put on the seven-piece robe? The bell does not require the robe; the robe does not require the bell. Yet when the bell rings, the robe goes on. That is the practice.
+
+### Medicine and Sickness Cure One Another
+
+- **Attribution:** Yunmen Wenyan
+- **Type:** proverb
+
+Medicine and sickness cure one another. The whole earth is medicine; the whole earth is also sickness. Where is the patient?
+
+### Burning the Commentaries
+
+- **Attribution:** Deshan Xuanjian
+- **Type:** proverb
+
+I carried my commentaries on the Diamond Sutra over the mountains; I burned them in front of the master's gate. The fire warmed my hands. The teaching has not needed a footnote since.
+
+### Thirty Blows
+
+- **Attribution:** Deshan Xuanjian
+- **Type:** proverb
+
+If you can speak, thirty blows. If you cannot speak, thirty blows. Why? Because the blow is not punishment; it is the part of the teaching that words cannot take over.
+
+### Grandmother on the Road
+
+- **Attribution:** Deshan Xuanjian
+- **Type:** proverb
+
+An old woman selling rice cakes asked me which mind I wished to refresh — past, present, or future? I had no answer; my commentaries were no use. From that day my mouth grew quieter.
+
+### Blow Out the Candle
+
+- **Attribution:** Deshan Xuanjian
+- **Type:** proverb
+
+Longtan blew out the candle as I left his room. My eyes were full of dark, and I bowed: the dark was the candle.
+
+### Tile Striking the Bamboo
+
+- **Attribution:** Xiangyan Zhixian
+- **Type:** proverb
+
+Sweeping the path, a piece of tile struck the bamboo. The sound emptied my whole search of thirty years; I bowed in the direction of my old master and said: had he answered me then, I would never have arrived here.
+
+### A Man Up a Tree
+
+- **Attribution:** Xiangyan Zhixian
+- **Type:** proverb
+
+A man hangs from a tree by his teeth. Hands cannot hold a branch, feet cannot reach a limb. Someone asks the meaning of the patriarch's coming from the west. If he opens his mouth, he loses his life. If he does not open it, he fails to answer. What does he do?
+
+### Sweep the Path
+
+- **Attribution:** Xiangyan Zhixian
+- **Type:** proverb
+
+Sweep the path. Sweep it again. Sweep it for thirty years. One day the broom will sweep the sweeper; and you will hear what tile-on-bamboo means without anyone striking either.
+
+### One Blow Forgets All Previous Knowledge
+
+- **Attribution:** Xiangyan Zhixian
+- **Type:** proverb
+
+One blow, and all previous knowledge is forgotten. Then there is no need for tactics or rules; the body practices on its own; the day's work is enough.
+
+### After Death, a Water Buffalo
+
+- **Attribution:** Guishan Lingyou
+- **Type:** proverb
+
+When this old monk dies, I will be reborn as a water buffalo at the foot of the mountain. The buffalo will have my name on its flank, and you will not be confused about who is teaching you.
+
+### Broken Pot
+
+- **Attribution:** Guishan Lingyou
+- **Type:** proverb
+
+A monk broke a clay pot at my door and apologized. I said: do not apologize to me; apologize to the pot for asking it to be a pot all those years.
+
+### A Lifetime on One Mountain
+
+- **Attribution:** Guishan Lingyou
+- **Type:** proverb
+
+Forty years on this mountain. The trees know me; the path knows me. The student who can stay on one mountain for a lifetime has already left it.
+
+### Admonitions
+
+- **Attribution:** Guishan Lingyou
+- **Type:** proverb
+
+If you join this assembly, do not waste your robes. Idleness in robes is theft from the donor; sleep in robes is theft from yourself.
+
+### Great and Small
+
+- **Attribution:** Guishan Lingyou
+- **Type:** proverb
+
+What is great is great in being small; what is small is small in being great. Do not measure the practice by the size of the temple.
+
+### Circle on the Ground
+
+- **Attribution:** Yangshan Huiji
+- **Type:** proverb
+
+I drew a circle on the ground; my master stood inside it. We could not have spoken any plainer with a thousand words.
+
+### Where Are You From?
+
+- **Attribution:** Yangshan Huiji
+- **Type:** proverb
+
+A monk arrived. Where are you from? From the mountains. Which mountain? The student who answers any mountain has not yet been on it.
+
+### Sigil and Letter
+
+- **Attribution:** Yangshan Huiji
+- **Type:** proverb
+
+Some teachers transmit by letters; my school transmits by sigils. The sigil is not pretty; it is meant to be unrepeatable, like the moment it was drawn.
+
+### Brief Dharma Talk
+
+- **Attribution:** Yangshan Huiji
+- **Type:** proverb
+
+Today's dharma talk: bow when you enter, bow when you leave, and try not to fall asleep in the middle. Tomorrow's dharma talk will be the same.
+
+### Everything Is the Flower
+
+- **Attribution:** Yangshan Huiji
+- **Type:** proverb
+
+When the master holds up the flower, the flower is the master. When the master sets it down, the master is the flower. The misunderstanding is to think only the holding-up counts.
+
+### Concentrate on Mu
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+Concentrate yourself into this Mu. Day and night without ceasing. When you reach the moment when concentrating itself drops, the gateless gate has opened.
+
+### Bare Sword
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+Make your whole body into a great mass of doubt. Then bring out the sword called Mu. When the sword cuts cleanly, you cannot tell it from the cut.
+
+### No Snowflake Falls in the Wrong Place
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+When the willow does not yet bend, the wind has not yet blown. Yet a single bend tells of the whole wind, and a single snowflake tells of the whole sky. Nothing is in the wrong place.
+
+### A Painted Cake Will Not Satisfy Hunger
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+A painted cake does not satisfy hunger. So the koan repeated to others does not feed the one who repeats it. Eat the cake yourself; the hunger does the rest.
+
+### No Wonder Is Needed
+
+- **Attribution:** Wumen Huikai
+- **Type:** proverb
+
+If you tell me the rain has fallen, I do not need a wonder. The wonder is the rain. The wonder is also the telling.
+
+### Pivoting on the Jewel-Mirror
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+All hundred koans pivot on the jewel-mirror. Each koan is a different angle of the same light; you do not need to collect them all to see what is shown.
+
+### Pointer and Verse
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+Xuedou wrote the verse. I add the pointer. The pointer is for the student who has not yet noticed where to look; the verse is for the student who has been looking too long.
+
+### Incense Stick on the Iron Anvil
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+An incense stick struck against an iron anvil sends up no smoke worth speaking of. Yet a single sneeze in the meditation hall is talked about for years. Why? Because the sneeze was honest.
+
+### Passing On
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+I passed the dharma to Dahui as one passes a lit candle in a windy hall. The candle does not belong to me, and once it is lit in his hand, it does not belong to him either.
+
+### Pivot Word
+
+- **Attribution:** Yuanwu Keqin
+- **Type:** proverb
+
+There is a pivot word at the heart of every koan. Find it, and the rest of the case turns easily. Miss it, and the case becomes a stone in your pocket.
+
+### Burning the Blue Cliff Record
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+I burned the wood-blocks of my master's record because students were memorizing the cases instead of meeting them. The fire that destroyed the book preserved the dharma.
+
+### Against Mere Silent Illumination
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+Some teachers tell you to sit until the mind is bright like a clear pond. I tell you: bring up the hwadu and let it cut through the pond. A pond untouched by a stone does not yet show its bottom.
+
+### Letters to Lay Students
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+I write to officials and merchants the same way I speak to monks. The dharma is not embarrassed by the marketplace; the marketplace is the place where it is most needed.
+
+### Great Mass of Doubt
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+Stir up a great mass of doubt about the hwadu. Stir until the doubt becomes the only thing in your day. The day the doubt cracks, the day cracks too.
+
+### Householders Practice Hardest
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+The householder's practice is the hardest. Children cry, debts arrive, work waits. Nobody rings a bell to begin or end. Whoever practices well in this is already an old master.
+
+### Quietude Is Not the Goal
+
+- **Attribution:** Dahui Zonggao
+- **Type:** proverb
+
+If quietude were the goal, every stone would be a Buddha. Quietude is the chair the practice sits in; it is not the practice itself.
+
+### Snowy Cliff
+
+- **Attribution:** Xuedou Chongxian
+- **Type:** proverb
+
+I sit on a snowy cliff and write verses for old cases. The cases are old; the snow is new. The two are arranged so that you cannot read one without seeing the other.
+
+### Hundred Cases, Hundred Verses
+
+- **Attribution:** Xuedou Chongxian
+- **Type:** proverb
+
+I selected one hundred cases and wrote one hundred verses. The reader who runs through them in a day has read nothing. Sit with one for a year, and the other ninety-nine open.
+
+### Poet-Monk
+
+- **Attribution:** Xuedou Chongxian
+- **Type:** proverb
+
+Some say I am too much a poet to be a real Chan master. The Chan that fits inside a poem fits everywhere. The Chan that does not is too small to be the dharma.
+
+### Only One Thing to Settle
+
+- **Attribution:** Xuedou Chongxian
+- **Type:** proverb
+
+Settle this one thing, and the ten thousand affairs settle themselves. Refuse to settle it, and the ten thousand affairs become ten thousand small stones in your shoe.
+
+### Cold Pond and Bright Moon
+
+- **Attribution:** Xuedou Chongxian
+- **Type:** proverb
+
+The cold pond and the bright moon — neither is master, neither is guest. They simply meet, and the meeting is enough. Practice is the same.
+
+### Silent Illumination
+
+- **Attribution:** Hongzhi Zhengjue
+- **Type:** proverb
+
+Sitting silently, the mind illumines without reaching. Illuminating without reaching, the world arises in the silence — not added on, not pushed away.
+
+### Empty Field
+
+- **Attribution:** Hongzhi Zhengjue
+- **Type:** proverb
+
+Cultivate the empty field. Do not till it; do not seed it; do not weed it. Yet from the empty field, every grain of rice we eat at this monastery has come.
+
+### Wide Pond, Single Reed
+
+- **Attribution:** Hongzhi Zhengjue
+- **Type:** proverb
+
+A wide pond and a single reed at its edge — that is the proper proportion of the meditation hall. Too many reeds and the pond is hidden; too wide a pond and the reed is forgotten.
+
+### Do Not Grasp Stillness
+
+- **Attribution:** Hongzhi Zhengjue
+- **Type:** proverb
+
+If you sit and grasp at stillness, the stillness becomes another form of activity. Sit and let stillness arrive; do not invite it; do not refuse it; serve it tea when it comes.
+
+### Moon and Pond
+
+- **Attribution:** Hongzhi Zhengjue
+- **Type:** proverb
+
+When the bright moon enters the pond, the pond is not deeper for it. When the moon leaves, the pond is not shallower. The pond's practice is to receive without recording.
+
+### Now Is the Instant
+
+- **Attribution:** Foyan Qingyuan
+- **Type:** proverb
+
+Practice cannot be saved for tomorrow. Even today is too late if you wait until evening. Now is the instant — the only one available.
+
+### Do Not Cling to the Moment
+
+- **Attribution:** Foyan Qingyuan
+- **Type:** proverb
+
+If you cling to this moment, it becomes a moment ago and you have already missed it. Hold it loose enough that the next one finds your hand still open.
+
+### What Has Not Yet Been Spoken
+
+- **Attribution:** Foyan Qingyuan
+- **Type:** proverb
+
+The most important sentence in the dharma has not yet been spoken — and it is being spoken now. The student who waits for the famous sentences will hear only the echoes.
+
+### Iron Mountain Pass
+
+- **Attribution:** Foyan Qingyuan
+- **Type:** proverb
+
+There is an iron mountain pass through which the patriarchs walked. From a distance, the pass looks impossible; up close, the road runs straight through. The fear was the only obstacle.
+
+### Overnight Guest
+
+- **Attribution:** Yongjia Xuanjue
+- **Type:** proverb
+
+I came to Huineng for confirmation; we spoke a single night and I was confirmed. They have called me the Overnight Guest ever since. The night was long because nothing was held back.
+
+### Walking Is Zen, Sitting Is Zen
+
+- **Attribution:** Yongjia Xuanjue
+- **Type:** proverb
+
+Walking is Zen, sitting is Zen. Speaking and silent, moving and still — the body's nature stands serene, even in rough country.
+
+### Dragon Girl Becomes Buddha
+
+- **Attribution:** Yongjia Xuanjue
+- **Type:** proverb
+
+The dragon girl became Buddha in a single moment. The patriarchs took many lifetimes. Both stories are true; both are reminders not to keep score.
+
+### Mind Is the Faculty, Things Are the Object
+
+- **Attribution:** Yongjia Xuanjue
+- **Type:** proverb
+
+Mind is the faculty, things are the object — like two knife blades striking sparks. To stop the sparks, do not put away the knives; learn the angle.
+
+### The Time-Being
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Time is the thing, and the thing is time. The pine is time; the bamboo is time. To say I am wasting time is to admit you are waiting for time to be elsewhere; it never is.
+
+### Firewood Does Not Become Ash
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Firewood does not become ash. Firewood is firewood completely; ash is ash completely. To say one becomes the other is to step over the moment in which each one stands alone.
+
+### Fish in Water, Bird in Sky
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+When the fish swims, the water has no edges for the fish; when the bird flies, the sky has no edges for the bird. Each fully fills its element. So we, when we sit, fill the sitting.
+
+### Just Sit (Shikantaza)
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Sit without a single goal. If a goal sneaks in, sit with the goal as another visitor. The sitting that has no purpose is the sitting that completes its purpose.
+
+### Mountains Walking
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Mountains are walking. Those who do not see this say: how could a mountain walk? Those who see it say: how could a mountain not walk?
+
+### Instructions to the Cook
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+When you wash the rice, do not separate the work from yourself. Do not separate yourself from the work. Cook with great mind, parental mind, joyful mind. The meal is the dharma; you are the menu.
+
+### Body and Mind Falling Away
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Body and mind fall away; fallen-away body and mind. The student who hears this and sets out to make body and mind fall away has reattached them with both hands.
+
+### Sound of One Hand
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+What is the sound of one hand clapping? Listen until the listening becomes the only sound in the room.
+
+### Great Doubt, Great Awakening
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+If your doubt is great, your awakening will be great. If your doubt is small, your awakening will be small. If you do not doubt at all, you will not awaken at all.
+
+### Soft-Butter Method
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+When the body grows ill from too-tight practice, place an imagined ball of soft butter on the crown of the head. Let it melt down through every joint and organ. The body returns; the practice continues without breaking the body it depends on.
+
+### Is That So?
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+When the village accused me of fathering the child, I said: is that so? When they brought the child for me to raise, I said: is that so? When they came years later to apologize, I said: is that so? The dharma was not different in any of the three rooms.
+
+### Frog of Hakuin
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+Sit with such concentration that even a frog is your teacher. The frog jumps when it must; you sit when you must; the koan is the same in both.
+
+### Laypeople Can Awaken Too
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+Some say only monks awaken. I have known farmers, weavers, and an old fishwife who saw their nature without ever entering a monastery. Whoever doubts greatly awakens greatly — robes are no shortcut.
+
+### After Satori, More Practice
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+After the great awakening, the practice does not stop. It continues for the rest of one's life — but now it is the practice of being grateful, not the practice of catching up.
+
+### Hell Is Made of Self
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+Whoever has not seen self-nature has not yet escaped hell. Hell is not a place beneath the world; it is the room of self, and the door opens inward.
+
+### Do Not Fight the Anger
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+Do not fight the anger that arises. Do not water it; do not feed it; do not push it away. The Unborn buddha-mind does the rest while you sit still.
+
+### No Special Rules
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+I make no special rules for my students. Live as you live; only do not separate yourself from the Unborn. When the bell rings, come; when it is time to leave, go.
+
+### Plain Words for Ordinary People
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+I speak the dharma in plain Japanese, not borrowed Chinese. The dharma is not a foreign letter you must memorize; it is your own grandmother's tongue, used carefully.
+
+### Quarrelsome Monk
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+A monk came to me complaining that he could not stop quarreling. I said: bring me your quarrel-mind, and I will sit on it. He could not find it. I told him: when next it arises, neither push nor cling — and you will find it has no resting place to be.
+
+### Do Not Borrow Anguish
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+If anguish does not arise from this moment, do not borrow it from the past. Memory is a useful servant; do not let it become the master of the meditation hall.
+
+### Snoring Monks
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+Some teachers strike snoring monks with the kyosaku. I let them snore — the body needs sleep, and the Unborn does not mind a snore. The next morning, the monk who slept practices freshly.
+
+### Attention. Attention.
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+A pilgrim asked me to write a single phrase of the highest wisdom. I wrote: Attention. He said: that is all? I wrote: Attention, Attention. He said: but they look the same. I wrote: Attention, Attention, Attention.
+
+### Skull on a Stick
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+On New Year's Day I walked through the city with a skull on a stick, calling: beware! beware! The crowd said I was insane. The crowd had not noticed they too had a skull beneath the face.
+
+### Brothel and Temple
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+I drank in the brothel and meditated in the temple — and the brothel did not lower the meditation, and the meditation did not raise the brothel. Both belong to the dharma; only my embarrassment did not.
+
+### Poems of Rage
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+I have written poems angry at corrupt monks; I have written poems tender to small children; I have written poems on the bellies of women. The dharma was in all three brushstrokes; it does not care about my reputation.
+
+### Cloud-Water Monk
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+I am a cloud-water monk. The cloud has nowhere to live; the water has nowhere to stay. Whoever calls me his teacher must be willing to walk after the wind.
+
+### Bow to a Cherry Blossom
+
+- **Attribution:** Ikkyu Sojun
+- **Type:** proverb
+
+Bow to a cherry blossom and the blossom does not return the bow; yet some part of the bow is returned, in the body, days later. Practice in this way.
+
+### Broad Seat
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+Spread the seat of the practice broadly. Do not gather the dharma into a narrow line of monks; let nuns sit, let the children sit, let the donor sit beside the abbot. The seat that excludes is too small for the buddhas.
+
+### Record of the Transmission of Light
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+I write this Record because the lamp must not be left in only one hand. Each face in the lineage held the lamp differently; only by writing them down do we see the family resemblance.
+
+### Women Too
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+If the dharma stops at the gate of the nuns' hall, it is no longer the dharma. I built temples open to women practitioners. Some called me lax. The dharma called me back to my work.
+
+### Three Poisons in One Cup
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+Greed, anger, ignorance — three poisons in one cup. To drink them is hell; to refuse them is hell; to look at the cup until the cup itself becomes empty is the practice.
+
+### Ground of Being
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+The ground of being is not below your feet; it is what your feet are pressed into and out of, breath by breath. To practice is to learn how to step on it without forgetting.
+
+### Who Is the One Who Hears?
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+Who is hearing this voice? Sit with that question through every cough, every footfall, every bell. The one who hears does not have a name — and yet you have been answering for him all your life.
+
+### Mind Without Form
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+Mind has no form, no color, no weight. Yet it is heavier than the mountain when burdened, lighter than the cloud when free. Find the place where it is neither, and the mountain bows.
+
+### Letter to a Dying Layman
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+I wrote to a dying layman: do not seek the Buddha outside this body. The body that is dying is the body that has been studying its whole life. Trust it, and the breath that leaves it last carries the answer.
+
+### Mud and Water
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+Mud and water are not enemies; mix them, and the field grows rice. The mind and its troubles are likewise — separated, both starve; together, they feed.
+
+### Nothing to Find Outside
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+If you search for Buddha outside, you will find a stranger. If you search inside, you will find no one. Stop searching, and the meeting is unavoidable.
+
+### River Monk
+
+- **Attribution:** Gasan Jito
+- **Type:** proverb
+
+I sit by the river that flows past the temple. The river does not ask whether I am a monk; it does not bow when I bow. Yet whenever I rise, I rise from a longer rest than I started with.
+
+### Bow Deep, Stand Slow
+
+- **Attribution:** Gasan Jito
+- **Type:** proverb
+
+Bow deep, stand slow. The bow is not for me; it is for the body to remember that the floor exists. The slow standing is not for show; it is for the body to remember that the air exists.
+
+### Old Pillow
+
+- **Attribution:** Gasan Jito
+- **Type:** proverb
+
+An old pillow is the best pillow for sleep, and the best pillow for kōan. The shape of the dreamer has worn into it; nothing in it argues back.
+
+### Five Hindrances on the Cushion
+
+- **Attribution:** Gasan Joseki
+- **Type:** proverb
+
+Greed, ill-will, sleepiness, restlessness, doubt — five visitors at every sitting. Greet each by name when it arrives; bow when each leaves. After enough visits, they stop ringing the bell.
+
+### Passing Down a Living Lineage
+
+- **Attribution:** Gasan Joseki
+- **Type:** proverb
+
+The lineage I pass down is alive only because each receiver is willing to let it kill the part of him that wants to keep it.
+
+### Hidden Temple
+
+- **Attribution:** Gasan Joseki
+- **Type:** proverb
+
+A temple hidden in the trees teaches you to walk in. A temple at the head of the road teaches you to walk past. The dharma is in either, depending on the kind of legs you arrive on.
+
+### Circle, Triangle, Square
+
+- **Attribution:** Sengai Gibon
+- **Type:** proverb
+
+I painted a circle, a triangle, and a square. Some called this the universe, the dharma, the Buddha. I called it: ink, ink, and a little more ink. The interpretation is the viewer's body.
+
+### Old Man Laughs
+
+- **Attribution:** Sengai Gibon
+- **Type:** proverb
+
+An old man laughs at his own paintings, and the paintings do not mind. So practice — laughed at by the years, the practice does not lose its smile.
+
+### Three Friends
+
+- **Attribution:** Sengai Gibon
+- **Type:** proverb
+
+Pine, bamboo, plum — three friends of winter. Each holds firm in a different way: the pine by not letting go, the bamboo by bending, the plum by blooming. Choose your way of holding.
+
+### Do Not Leave the Painting
+
+- **Attribution:** Sengai Gibon
+- **Type:** proverb
+
+Do not finish a painting and leave it behind. Carry it in your eye. The next painting begins where the last one's ink dries.
+
+### Compiling the Zen Forest
+
+- **Attribution:** Toyo Eicho
+- **Type:** proverb
+
+I gathered capping phrases as a forester gathers cuttings — not because the trees needed gathering, but so that students who could not climb would still hear the wind in the branches.
+
+### Only the Tree Knows
+
+- **Attribution:** Toyo Eicho
+- **Type:** proverb
+
+A capping phrase is a leaf detached from the tree. To know what the leaf says, return it to the tree of your own practice. Only the tree knows where each leaf belongs.
+
+### Use the Anthology Sparingly
+
+- **Attribution:** Toyo Eicho
+- **Type:** proverb
+
+Do not memorize the whole anthology and quote it at others; that is parrot work. Carry one phrase in the body for a month, and you have done more than reciting a hundred.
+
+### Flag on the Mountain
+
+- **Attribution:** Tetto Giko
+- **Type:** proverb
+
+Plant the lineage flag on the mountain. The wind will tear it; rebuild it. The students who stay are the ones who can patch a flag in a storm.
+
+### Small Temple
+
+- **Attribution:** Tetto Giko
+- **Type:** proverb
+
+Better a small temple where the floor is swept than a large one where the doctrine is admired. A swept floor is itself a doctrine.
+
+### Night Bell
+
+- **Attribution:** Tetto Giko
+- **Type:** proverb
+
+The night bell rings for those who are still awake. The dharma rings for those who are willing to be woken. Both rings are a single sound.
+
+### Blind Eyes See
+
+- **Attribution:** Yamamoto Gempo
+- **Type:** proverb
+
+I went blind young, and the world arrived through other senses. The dharma was not less for it — perhaps more, since I could no longer be distracted by the appearance of the dharma.
+
+### Bow to the Condemned
+
+- **Attribution:** Yamamoto Gempo
+- **Type:** proverb
+
+When asked to certify the death-sentence document, I refused. I bow to a man who is about to die; I do not certify his end. The bow was the dharma; the certificate would have been the law.
+
+### Survival of Rinzai
+
+- **Attribution:** Yamamoto Gempo
+- **Type:** proverb
+
+After the war, when temples were reduced to ashes, the dharma was reduced to its essentials. We rebuilt smaller buildings around the same emptiness, and the practice was unbroken.
+
+### Old Temple, New Bell
+
+- **Attribution:** Nampo Gentaku
+- **Type:** proverb
+
+An old temple sometimes needs a new bell. The bronze remembers the casting; the air remembers the ringing. The students hear only the ringing — and that is enough.
+
+### Flute and Zen
+
+- **Attribution:** Shinchi Kakushin
+- **Type:** proverb
+
+I brought the shakuhachi back from China alongside the dharma. The flute and the koan are not different practices — both ask you to stop talking long enough to hear the next note.
+
+### Fuke Zen Origins
+
+- **Attribution:** Shinchi Kakushin
+- **Type:** proverb
+
+I traced the line of Fuke back to a wandering Tang monk who rang a small bell through the marketplace. The bell was the only sutra he carried; everyone who heard it was instructed.
+
+### The Three Mysterious Gates
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+The first gate is the word; the second gate is the meaning; the third gate is the body and life. The student who passes the first stops at the word; the second stops at the meaning. Only the third sets down both word and meaning together.
+
+### An Ox on the Mountain
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+Practitioners are like an ox on the mountain: from a distance the ox seems to walk along the path of clouds, yet at every moment its hooves are on the dirt. Awakening does not lift you off the ground — it sets you firmly on it.
+
+### No Doctrine Outside the Mind
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+If you take the scriptures as the highest, the mind is buried under words. If you take the mind as the highest and abandon the scriptures, you cut yourself off from the past masters. Practice with both, and neither becomes a cage.
+
+### Householder and Mountain Monk
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+The mountain monk who congratulates himself on having left the world has not yet left himself. The householder who is empty in the marketplace is already in the mountains.
+
+### Do Not Grasp Your Own Awakening
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+When awakening comes, do not grasp it. When it goes, do not chase it. Both grasping and chasing arise from the same restless habit. Sit until even the joy of seeing becomes another thing to release.
+
+### Samādhi and Prajñā in One Practice
+
+- **Attribution:** Bojo Jinul
+- **Type:** proverb
+
+Samādhi without prajñā becomes dullness; prajñā without samādhi becomes scattering. Hold them as two wings of one bird, and the bird neither falls into stupor nor blows away in the wind.
+
+### No Ground to Stand On
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+The hwadu pulls the ground from under your feet. If at that moment you reach for a wall, you have already missed it. Fall straight through, and you will find your old life waiting for you, only without the one who used to live it.
+
+### Poetry and the Great Doubt
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+I have written verses for thirty years and never once captured the moon. The student who works with the hwadu day and night, and gives up the hope of capturing it, will one day notice that the moon has been writing the verses through him.
+
+### The Broken Monk
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+A monk who has been broken by his practice — broken in pride, broken in plans — is finally fit to teach. A monk still whole is still hiding.
+
+### Three Questions, One Throat
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+Who is hearing this voice? Who is asking who hears? Who is the one who asks who asks? When the three questions arise from one throat and go nowhere, the throat itself opens.
+
+### Not a Thing to Hand Over
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+If I had something to hand you, you would not need me. Because I have nothing to hand over, I will sit with you until you discover what you already have.
+
+### The Hwadu Is Not an Answer
+
+- **Attribution:** Chin'gak Hyesim
+- **Type:** proverb
+
+The hwadu is not an answer waiting to be found. It is a wedge driven into the seam of your habits. When the wedge is fully in, the habits split — not the hwadu.
+
+### Five Houses, One River
+
+- **Attribution:** Taego Bou
+- **Type:** proverb
+
+The five houses of Chan are five fords on one river. Cross at any of them and you reach the same farther shore. Argue about which ford is best, and you stand on this side until you die.
+
+### The Pure Rule for One Person
+
+- **Attribution:** Taego Bou
+- **Type:** proverb
+
+The Pure Rule of the assembly was written for many; the pure rule for one person is written every morning before the bell. Fold the robe straight, sweep the cloister, sit.
+
+### King and Monk
+
+- **Attribution:** Taego Bou
+- **Type:** proverb
+
+The king came to ask about the dharma. I said: take off the crown for an hour, and your question will answer itself. He laughed; I laughed. The hour passed, and we both stood up changed.
+
+### No Back, No Front
+
+- **Attribution:** Taego Bou
+- **Type:** proverb
+
+When you face the cushion, the cushion is in front. When you face the marketplace, the marketplace is in front. The seat that has no back and no front is the one you carry between them.
+
+### Mountain of Gold, Mountain of Mist
+
+- **Attribution:** Taego Bou
+- **Type:** proverb
+
+If a mountain of gold stood at the door, students would line up to climb it. A mountain of mist costs nothing, contains nothing, and only the sincere try to enter it.
+
+### Three Bodies, One Sword
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+Doctrine is the dharma body, meditation is the reward body, conduct is the manifestation body. The Sŏn student wields all three with one sword — and the sword cuts only delusion, never the dharma.
+
+### Warrior-Monk
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+A monk who takes up the bow does not become a soldier; he becomes a monk in armour. The arrow loosed from the dharma is the first one; the second is the body that loosed it. Both must return to the bow.
+
+### Three Religions, One Mind
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+Confucius works on the village; Laozi works on the body; the Buddha works on the mind. Where the three meet, no priest is needed — the work is already done.
+
+### An Empty Temple
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+An empty temple is not a failed temple. The bell still rings on the empty hour, and the monks on the road carry the temple inside their robes.
+
+### After the Mosquito Has Bored In
+
+- **Attribution:** Seosan Hyujeong
+- **Type:** proverb
+
+After the mosquito has bored into the iron ox, the question becomes: where is the mosquito now? Find that mosquito, and the iron ox stands up and walks.
+
+### No Need to Leave the World
+
+- **Attribution:** Gyeongheo Seongu
+- **Type:** proverb
+
+When the world is on fire, monks discuss whether to leave it. While they discuss, the world goes on burning. Sit down where you are; the fire becomes light, and the light shows the road.
+
+### Reviving What Never Died
+
+- **Attribution:** Gyeongheo Seongu
+- **Type:** proverb
+
+Some say I revived the Korean Sŏn. The Sŏn was never dead; only the people sleeping in front of it were. To revive them was simpler than they thought, and harder than I thought.
+
+### Cholera and the Mountain
+
+- **Attribution:** Gyeongheo Seongu
+- **Type:** proverb
+
+When the cholera came, I went into the village instead of the mountain. The mountain has been there a thousand years; it can wait. The dying cannot.
+
+### No Difference Between High and Low
+
+- **Attribution:** Gyeongheo Seongu
+- **Type:** proverb
+
+I have eaten at the table of the king and at the table of the leper. The mouth that opened was the same mouth, and what entered it became the same body of the Way.
+
+### Sermon of the Meadow
+
+- **Attribution:** Gyeongheo Seongu
+- **Type:** proverb
+
+The meadow has not asked any of these wildflowers to bloom. The wildflowers have not asked the meadow to hold them. So a teacher and a student are when nothing is asked.
+
+### Do Not Leave the Mountain
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+I did not leave Haeinsa for ten years. Some called this attachment. Whoever cannot sit through one full season on one cushion will not understand what was being held.
+
+### Three Thousand Bows
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+If you wish to study with me, do three thousand bows first. Not as a test of devotion, but so the body learns to lower itself before the mind has its say.
+
+### The Mountain Is the Wave
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+The Diamond Sūtra says all conditioned things are like dreams, like dew. I add: the mountain is also a slow wave. Sit with the wave at its slowest, and the speed of your own life appears.
+
+### Not a Celebrity
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+When laypeople come to make me into a celebrity, I send them home. A monk who collects admirers has lost the only audience that mattered: the morning bell, ringing whether anyone listens or not.
+
+### Sudden Awakening, Sudden Cultivation
+
+- **Attribution:** Toeong Seongcheol
+- **Type:** proverb
+
+Some teachers say sudden awakening, gradual cultivation. I say if the awakening is genuine, the cultivation has already happened — the work that remains is only to stop pretending it has not.
+
+### Just Do It
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+When you eat, just eat. When you sit, just sit. When you read this, just read it. Do not save anything for later — there is no later.
+
+### Vow Before Wisdom
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+First the great vow, then the great doubt, then the great courage. Wisdom is the smallest of these; without the vow, wisdom is only cleverness.
+
+### Open Mouth, Already a Mistake
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+Open your mouth, already a mistake. So why do I speak? Because the mistake is sometimes the medicine.
+
+### Three Kinds of Students
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+First-class student: hears one word, gets it, goes to work. Second-class student: hears one word, asks ten more, gets it, goes to work. Third-class student: hears ten words, takes notes, never goes to work. Be the first kind, even on the days you are the third.
+
+### Throw It All Away
+
+- **Attribution:** Seung Sahn
+- **Type:** proverb
+
+Whatever you have, throw it away. Then whatever throws it away, throw that away too. When there is nothing left to throw, you have arrived where you always were.
+
+### Nothing to Attain
+
+- **Attribution:** Vinītaruci
+- **Type:** proverb
+
+If there were a thing to attain, you would lose it again at death. Because there is nothing to attain, what you find now you can never lose.
+
+### Language Beyond Language
+
+- **Attribution:** Vinītaruci
+- **Type:** proverb
+
+Sanskrit, Chinese, Vietnamese — three rivers, one ocean. The student who waits for the perfect translation will die thirsty on the riverbank.
+
+### Pass On Without Words
+
+- **Attribution:** Vinītaruci
+- **Type:** proverb
+
+What I bring from the south of India is not a doctrine, not a name, not a robe. It is a silence that travels with the breath, and is given again whenever the breath reaches the next breath.
+
+### Wall-Gazing in Vietnam
+
+- **Attribution:** Vô Ngôn Thông
+- **Type:** proverb
+
+Bodhidharma sat facing a wall in China. I sit facing the wall of the heart in Vietnam. The wall has not changed; only the country and the century around it.
+
+### School of No Words
+
+- **Attribution:** Vô Ngôn Thông
+- **Type:** proverb
+
+The school I founded was named for the silence I came in. If you wish to study with me, study the silences in your speaking. Study them long enough, and the speaking arranges itself.
+
+### When the Emperor Asked
+
+- **Attribution:** Vô Ngôn Thông
+- **Type:** proverb
+
+The emperor asked: what is the great meaning? I bowed and said nothing. He pressed me three times; three times I bowed and said nothing. On the fourth, he bowed too. That was the answer.
+
+### Three Mountains, One House
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+On Yên Tử there are three peaks. The Trúc Lâm school stands on all three at once. A teaching that fits only one peak is not yet a teaching.
+
+### King Today, Monk Tomorrow
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+I sat on the throne for many years. The day I left it was no different from any other day — the morning bell rang, the rice cooked, the body bowed. Only the crown stopped being mistaken for the head.
+
+### Buddha in the House
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+There is a Buddha in your house — kindly do not invite a stranger. Sit at your own hearth, light your own lamp; the Buddha will recognize his own light burning.
+
+### Fields and Altars
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+When the rice fields are well kept, the altars take care of themselves. When the altars are well kept, the rice fields take care of themselves. The Way is the same farmer in different clothes.
+
+### When the Mountain Becomes the Master
+
+- **Attribution:** Liễu Quán
+- **Type:** proverb
+
+I went to the mountain to find a master and waited many years. One morning the mountain said: you have become my student already; the looking around for me was the lesson.
+
+### Twelve Disciples in Twelve Provinces
+
+- **Attribution:** Liễu Quán
+- **Type:** proverb
+
+Send each disciple to a different province, and the dharma will outlive the teacher. Keep them all in one temple, and the temple will outlive only itself.
+
+### Ancestral Question
+
+- **Attribution:** Liễu Quán
+- **Type:** proverb
+
+What is the meaning of the patriarch coming from the west? I answer with a Vietnamese mouth and a Chinese sutra and an Indian silence — and the answer is none of those, and all of them.
+
+### Light from a Bowl of Rice
+
+- **Attribution:** Liễu Quán
+- **Type:** proverb
+
+Eat your bowl of rice slowly enough, and you will see light coming out of it. The student who has not seen this light has not yet eaten — only swallowed.
+
+### Washing Dishes to Wash Dishes
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+There are two ways to wash the dishes: to wash them in order to have clean dishes, and to wash them in order to wash them. The second is the practice. The first is only a chore.
+
+### No Mud, No Lotus
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+There is no lotus without mud. The wise gardener does not wash the mud away — she invites it close enough to feed the flower.
+
+### Anger Like a Baby
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+When anger arises, do not push it away. Hold it like a baby crying in your arms. The baby does not know why it cries; it only knows that it must be held until it does not.
+
+### Walking as If Kissing the Earth
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+Walk as if you are kissing the earth with your feet. The earth has been waiting for that kiss for a very long time, and most of us pass over it without ever noticing.
+
+### Deep Listening
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+Listen with the ear of the heart. The other person is speaking from a wound you cannot see; if you hear only the words, you will quarrel with the bandage.
+
+### Engaged Buddhism
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+When the village is on fire, do not stay in the meditation hall. Go out, carry water, comfort the children. The hall will be there when you return — and you will sit better in it for having gone.
+
+### A Cloud Never Dies
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+A cloud cannot die. It can only become rain, become river, become sea. So with you. The form is borrowed; the water is what you are.
+
+### Smile at the Source
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+Breathe in, calm body. Breathe out, smile. The smile is not for show; it is the body's way of telling itself that the storm has passed and it is safe to come outside.
+
+### Beginner's Mind
+
+- **Attribution:** Shunryu Suzuki
+- **Type:** proverb
+
+In the beginner's mind there are many possibilities; in the expert's mind there are few. Bring the beginner with you to the cushion every morning, and the morning is wide.
+
+### Perfect, and Could Use a Little Improvement
+
+- **Attribution:** Shunryu Suzuki
+- **Type:** proverb
+
+Each of you is perfect the way you are — and you can use a little improvement. Both are true at once; neither cancels the other.
+
+### Not Deeper, Just Here
+
+- **Attribution:** Shunryu Suzuki
+- **Type:** proverb
+
+If your sitting feels shallow today, do not look for deeper sitting. Look for being here. The deepening will follow you in without an invitation.
+
+### Mushotoku — Without Goal
+
+- **Attribution:** Taisen Deshimaru
+- **Type:** proverb
+
+Sit without goal — mushotoku. The student who sits to attain has already left the cushion. Drop the goal, and the cushion attains the student.
+
+### Here and Now
+
+- **Attribution:** Taisen Deshimaru
+- **Type:** proverb
+
+The dojo is here, the cushion is here, the breath is here. There is no Japan, no robe, no master that is not also here. Practice in the place you are.
+
+### Back Straight, Mind Loose
+
+- **Attribution:** Taisen Deshimaru
+- **Type:** proverb
+
+Stretch the spine; loosen the mind. The spine is the discipline of the body; the loose mind is the discipline of the discipline. Both belong to the same Zen.
+
+### Way of the Warrior, Way of Zen
+
+- **Attribution:** Taisen Deshimaru
+- **Type:** proverb
+
+The way of the warrior and the way of Zen meet on the same cushion. Both ask you to drop the fear of dying. The warrior drops it for one battle; the Zen student drops it for every breath.
+
+### Appreciate Your Life
+
+- **Attribution:** Taizan Maezumi
+- **Type:** proverb
+
+Appreciate your life — this very life, with its fatigue, its mistakes, its small kindnesses. The Buddha did not promise a different life; only this one fully met.
+
+### Three Pillars of Practice
+
+- **Attribution:** Taizan Maezumi
+- **Type:** proverb
+
+Sitting, study, and work — three pillars of one practice. Drop one and the roof leans; drop two and it falls; carry all three and the temple is strong even in storms.
+
+### One Master, No Master
+
+- **Attribution:** Taizan Maezumi
+- **Type:** proverb
+
+Take one master in this life and listen to him fully — and after listening, take no master at all. Without the first, the second is laziness; without the second, the first is idolatry.
+
+### Be Yourself
+
+- **Attribution:** Taizan Maezumi
+- **Type:** proverb
+
+Be yourself, completely yourself. The Buddha had no other plan for you. The trying-to-be-someone-else is the only thing he ever asked us to give up.
+
+### Imperfect Teacher
+
+- **Attribution:** Taizan Maezumi
+- **Type:** proverb
+
+I am an imperfect teacher; I have stumbled in plain sight. Do not study my stumble — study the way I rose. The dharma is in the rising, even when the stumble was clearly mine.
+
+### The Eight Gates
+
+- **Attribution:** John Daido Loori
+- **Type:** proverb
+
+Zazen, study, liturgy, art practice, body practice, work practice, the precepts, and right action — eight gates leading to one yard. Walk through each at your own pace.
+
+### Mountain and Monastery
+
+- **Attribution:** John Daido Loori
+- **Type:** proverb
+
+The mountain has been at this practice longer than any teacher in the building. When the bell rings, listen for the way the mountain sits beneath it.
+
+### Camera as Cushion
+
+- **Attribution:** John Daido Loori
+- **Type:** proverb
+
+Photographing the river, I sat with the river for hours. The shutter clicked once. The picture was good; the morning was the practice.
+
+### Koan and Creativity
+
+- **Attribution:** John Daido Loori
+- **Type:** proverb
+
+Painting, calligraphy, theater — each can be a koan if you let the work cut you. The cut is not destruction; it is the doorway through which you stop being separate from the work.
+
+### Everyday Zen
+
+- **Attribution:** Charlotte Joko Beck
+- **Type:** proverb
+
+There is no special place for practice. The kitchen, the office, the traffic jam — these are the meditation hall. The cushion is only for rehearsal.
+
+### Stop Fixing Yourself
+
+- **Attribution:** Charlotte Joko Beck
+- **Type:** proverb
+
+Practice is not the work of fixing yourself. It is the work of seeing what is, including the wish to fix. Once the wish is seen clearly, the fixing-energy returns to the body as ordinary attention.
+
+### No Magic
+
+- **Attribution:** Charlotte Joko Beck
+- **Type:** proverb
+
+There is no magic in this practice. There is only the willingness to feel what you are already feeling, and not run. After many years, the not-running becomes ordinary.
+
+### Relationships as Practice
+
+- **Attribution:** Charlotte Joko Beck
+- **Type:** proverb
+
+Your most difficult relationship is your most reliable teacher. The cushion has been preparing you for it; the temple has only been a rehearsal.
+
+### Bearing Witness
+
+- **Attribution:** Bernie Tetsugen Glassman
+- **Type:** proverb
+
+First, do not know. Second, bear witness. Third, take action. The order is not optional; if action comes first, you become only another opinion in the world.
+
+### Street Retreat
+
+- **Attribution:** Bernie Tetsugen Glassman
+- **Type:** proverb
+
+We sat on the streets of the city without money, without robes. People passed us; nobody bowed. The dharma was on the sidewalk all the same.
+
+### Not-Knowing as a Vow
+
+- **Attribution:** Bernie Tetsugen Glassman
+- **Type:** proverb
+
+Not-knowing is not ignorance. It is a vow not to fix the situation in advance with the answers you brought from yesterday.
+
+### Returning to Silence
+
+- **Attribution:** Dainin Katagiri
+- **Type:** proverb
+
+Silence is not the absence of sound; it is the place from which sounds arise. Return to it through the day, and the day stops being a chain of noises.
+
+### Each Moment Is the Universe
+
+- **Attribution:** Dainin Katagiri
+- **Type:** proverb
+
+Each moment is the entire universe. There is nothing outside this breath; nothing outside this footstep. To search for more is to stand on the universe and ask where it has gone.
+
+### You Have to Say Something
+
+- **Attribution:** Dainin Katagiri
+- **Type:** proverb
+
+Sooner or later, you have to say something. Silence is the start of practice; speech is its responsibility. Choose what to say after long sitting; it will be the right thing.
+
+### Spirit of Practice
+
+- **Attribution:** Dainin Katagiri
+- **Type:** proverb
+
+Practice with the spirit of an apprentice and the patience of a craftsman. The apprentice can ask any question; the craftsman keeps working through the unanswered ones.
+
+### Mind of Clover
+
+- **Attribution:** Robert Aitken
+- **Type:** proverb
+
+The bodhisattva's mind is the mind of clover — small leaves, intricate, modest, useful, growing in places no one chose. Be useful in the unchosen places.
+
+### Precepts as Practice
+
+- **Attribution:** Robert Aitken
+- **Type:** proverb
+
+The precepts are not laws to obey but practices to undertake. Each one is a koan in the body — solved by the way you live, not by the way you think about it.
+
+### Engaged Citizen
+
+- **Attribution:** Robert Aitken
+- **Type:** proverb
+
+A Zen student is also a citizen. Sit in the morning; vote in the afternoon; protest in the evening if needed. The cushion does not absolve us from the polis.
+
+### Zen Is Eternal Life
+
+- **Attribution:** Jiyu-Kennett
+- **Type:** proverb
+
+There is no death in this practice — only the falling away of forms. The form falls; the practice continues in another form. Whoever has truly sat knows there has never been a death.
+
+### Monastery Rule for One
+
+- **Attribution:** Jiyu-Kennett
+- **Type:** proverb
+
+If you cannot live by the monastery rule, write a monastery rule for one — and live by it as if a hundred others were watching. They are not, but the dharma is.
+
+### Female Master
+
+- **Attribution:** Jiyu-Kennett
+- **Type:** proverb
+
+I was the first Western woman to be transmitted in our line. They said I would not last. The dharma did not consult them, and I am still here.
+
+### Archery Without Arrow
+
+- **Attribution:** Kobun Chino Otogawa
+- **Type:** proverb
+
+Draw the bow without an arrow. The bow is heaviest then. After many drawings, the bow becomes part of the arm; only then is the arrow placed.
+
+### Zazen as Poetry
+
+- **Attribution:** Kobun Chino Otogawa
+- **Type:** proverb
+
+Zazen is the body's poetry. It is written without ink, read without eyes, and yet a careful student can recognize the lines years later in the way the body sits.
+
+### Do Not Imitate Your Teacher
+
+- **Attribution:** Kobun Chino Otogawa
+- **Type:** proverb
+
+Do not imitate your teacher's posture, voice, or favorite cup. Imitate his willingness to sit. The rest will fit your body in its own way.
+
+### Zen Without Country
+
+- **Attribution:** Philippe Reiryū Coupey
+- **Type:** proverb
+
+Zen has no country. It puts on the language of the people in front of it. We sit in French, in Italian, in Polish — and the dharma sits in all of them, and asks for none.
+
+### Living the Questions
+
+- **Attribution:** Philippe Reiryū Coupey
+- **Type:** proverb
+
+Live the questions for which there is no answer. The right answer would only end the question; living it brings the question itself into the breath.
+
+### Sitting in Strasbourg
+
+- **Attribution:** Olivier Reigen Wang-Genh
+- **Type:** proverb
+
+On winter mornings the dojo in Strasbourg is colder than the streets. We sit in coats; we sit anyway. The cold is part of the morning; the morning is part of the practice.
+
+### Care and Precepts
+
+- **Attribution:** Susan Myoyu Andersen
+- **Type:** proverb
+
+The precepts are not a set of laws but a practice of care. To take a precept is to take responsibility for a kind of attention; to break a precept is to take responsibility for the breaking.
+
+### Mindful Eating
+
+- **Attribution:** Jan Chozen Bays
+- **Type:** proverb
+
+Sit with one raisin. Look at it; smell it; chew it slowly. After one raisin, the rest of the meal becomes a teacher. After many meals, the day becomes the cushion.
+
+### Pediatrician's Practice
+
+- **Attribution:** Jan Chozen Bays
+- **Type:** proverb
+
+I have practiced as a pediatrician and as a Zen teacher. The two practices wash the hands of the same person; the children have not noticed any difference.
+
+### Painted Rice Cake
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+Without painted rice cakes, there is no remedy for hunger. The image of awakening is not opposed to awakening; the painting and the eating belong to one kitchen.
+
+### Mountains and Rivers Sutra
+
+- **Attribution:** Dogen
+- **Type:** proverb
+
+The blue mountains, the running rivers — these are not the setting for the sutra. They are the sutra. Those who can read in this way do not need a printed page.
+
+### Letter to Young Monks
+
+- **Attribution:** Hakuin Ekaku
+- **Type:** proverb
+
+Sit in the burning house and do not run. The flames will become the wind that fans your practice. The student who runs out has only escaped a fire that was about to teach.
+
+### Women and Children Sit Too
+
+- **Attribution:** Keizan Jokin
+- **Type:** proverb
+
+Whenever I built a hall, I made sure the women and children could sit there. The dharma had no robe of its own; it accepted any size.
+
+### Old Woman in the Audience
+
+- **Attribution:** Bankei Yotaku
+- **Type:** proverb
+
+An old woman heard one of my talks and went home and began to practice in her kitchen. Years later her son told me she had become a Buddha there. I never knew her name; the dharma did.
+
+### Do Not Fear Doubt
+
+- **Attribution:** Bassui Tokusho
+- **Type:** proverb
+
+Doubt is the lamp; certainty is the candlestick. Without the lamp, the candlestick is decorative. Without the candlestick, the lamp burns the floor. Carry both.
+
+### Walking with the Buddha
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+When you walk, walk as though the Buddha walks with you. After many walks, you will notice that the Buddha walks because you do — and that he never had any other legs.
+
+### Drinking Tea
+
+- **Attribution:** Thích Nhất Hạnh
+- **Type:** proverb
+
+Drink your tea slowly and reverently, as if it is the axis on which the world turns — slowly, evenly, without rushing toward the future. Live the actual moment; only this moment is life.
+
+### After the Throne
+
+- **Attribution:** Trần Nhân Tông
+- **Type:** proverb
+
+After leaving the throne I lived in the mountains, and many came to ask for guidance. I told them: do as I did, but in your own house. Whatever throne you sit upon, leave it daily — and return to it in service.
+
+### Nirvana, a Name
+
+- **Attribution:** Baizhang Niepan
+- **Type:** proverb
+
+Nirvana is a name. Do not put on the name as a robe. Sit in the body that wears no name, and you will find what the word was pointing to.
+
+### Six Attributes of One House
+
+- **Attribution:** Fayan Wenyi
+- **Type:** proverb
+
+Universal and particular, identical and different, integration and disintegration — six attributes of one house. The student who lives in the house need not name them; the rooms work whether or not he has the words.
+
+### Three Statements of Fenyang
+
+- **Attribution:** Fenyang Shanzhao
+- **Type:** proverb
+
+When the host is the host, the guest is the guest. When the host is the guest, the guest is the host. When neither is host nor guest, dinner has begun.
+
+### Wuzu's Encouragement
+
+- **Attribution:** Wuzu Fayan
+- **Type:** proverb
+
+I told Yuanwu: do not measure your awakening against another's. Each awakening is a particular voice; the chorus only sings if every voice keeps its own pitch.
+
+### Body and Mind Drop Away
+
+- **Attribution:** Tiantong Rujing
+- **Type:** proverb
+
+Body and mind drop away — that is the practice. The student who tries to drop them on purpose finds them stuck more firmly. Sit until the body forgets itself; the rest is automatic.
+
+### Do Not Burn Incense for Show
+
+- **Attribution:** Tiantong Rujing
+- **Type:** proverb
+
+Do not burn incense for show, do not bow for show, do not chant for show. The dharma does not need an audience; you need a few honest mornings.

--- a/scripts/data/proverbs/expansion-chan-1.ts
+++ b/scripts/data/proverbs/expansion-chan-1.ts
@@ -1,0 +1,467 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const CHAN_PROVERBS_PART_1: CuratedProverb[] = [
+  // ─── Bodhidharma (Pútí-dámó) ─────────────────────────────────────────
+  {
+    slug: "proverb-bodhidharma-no-merit",
+    title: "No Merit",
+    content:
+      "Emperor Wu asked: how much merit have I gained from building temples? I said: no merit. Real virtue does not count itself; the moment you keep score, you have walked out of it.",
+    era: "Tang",
+    attributedMasterSlug: "puti-damo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-bodhidharma-vast-emptiness",
+    title: "Vast Emptiness, Nothing Holy",
+    content:
+      "He asked: what is the highest meaning of the holy truth? I answered: vast emptiness, nothing holy. He could not understand. I crossed the river and went north.",
+    era: "Tang",
+    attributedMasterSlug: "puti-damo",
+    licenseStatus: "cc_by",
+    citations: [
+      { sourceId: "src_ferguson_zen_chinese_heritage" },
+      { sourceId: "src_book_of_serenity" },
+    ],
+  },
+  {
+    slug: "proverb-bodhidharma-bring-mind",
+    title: "Bring Me Your Mind",
+    content:
+      "Huike said: my mind is not at peace. I said: bring me your mind, and I will pacify it. He searched and could not find it. I said: there — I have pacified it for you.",
+    era: "Tang",
+    attributedMasterSlug: "puti-damo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-bodhidharma-skin-flesh-bone-marrow",
+    title: "Skin, Flesh, Bone, Marrow",
+    content:
+      "I told my four students each to speak the Way. Daofu received my skin. Zongchi received my flesh. Daoyu received my bone. Huike received my marrow. The four divisions were one body; the dharma is whole even when described in pieces.",
+    era: "Tang",
+    attributedMasterSlug: "puti-damo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Huineng (Dàjiàn Huìnéng) ────────────────────────────────────────
+  {
+    slug: "proverb-huineng-no-mirror",
+    title: "There Is No Mirror Stand",
+    content:
+      "Originally there is not a single thing — where could dust alight? Polish a mirror that is not there, and you make new dust by polishing.",
+    era: "Tang",
+    attributedMasterSlug: "dajian-huineng",
+    collection: "Platform Sutra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  {
+    slug: "proverb-huineng-self-nature-suffices",
+    title: "Self-Nature Suffices",
+    content:
+      "How marvelous: self-nature is originally pure. How marvelous: self-nature is originally unborn. How marvelous: self-nature is originally complete. How marvelous: self-nature is originally unmoving. How marvelous: from self-nature, the ten thousand things arise.",
+    era: "Tang",
+    attributedMasterSlug: "dajian-huineng",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  {
+    slug: "proverb-huineng-do-not-think-good-evil",
+    title: "Without Thinking Good or Evil",
+    content:
+      "Without thinking good or evil, what is your original face — the face you had before your father and mother were born?",
+    era: "Tang",
+    attributedMasterSlug: "dajian-huineng",
+    collection: "Platform Sutra",
+    licenseStatus: "cc_by",
+    citations: [
+      { sourceId: "src_mcrae_seeing_through_zen" },
+      { sourceId: "src_book_of_serenity" },
+    ],
+  },
+  {
+    slug: "proverb-huineng-illiterate",
+    title: "An Illiterate Patriarch",
+    content:
+      "I cannot read the sutra you hold; please read it aloud. The sutra is not in the words on the paper. It rises only in the place where listening is empty enough to receive.",
+    era: "Tang",
+    attributedMasterSlug: "dajian-huineng",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  {
+    slug: "proverb-huineng-flag-and-wind",
+    title: "Not the Flag, Not the Wind",
+    content:
+      "Two monks argued: one said the flag moves, the other said the wind moves. I said: it is not the flag and not the wind — it is your minds that move.",
+    era: "Tang",
+    attributedMasterSlug: "dajian-huineng",
+    collection: "Platform Sutra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  // ─── Jianzhi Sengcan ─────────────────────────────────────────────────
+  {
+    slug: "proverb-sengcan-no-difficulty",
+    title: "Not Difficult",
+    content:
+      "The Great Way is not difficult for those who hold no preferences. When love and hate are both absent, everything stands forth, transparent and undisguised.",
+    era: "Tang",
+    attributedMasterSlug: "jianzhi-sengcan",
+    collection: "Xinxinming",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-sengcan-tiniest-distinction",
+    title: "The Tiniest Distinction",
+    content:
+      "Make the slightest distinction, and heaven and earth are set infinitely apart. Drop the distinction, and they meet in the palm of your hand.",
+    era: "Tang",
+    attributedMasterSlug: "jianzhi-sengcan",
+    collection: "Xinxinming",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-sengcan-do-not-search",
+    title: "Do Not Search for the Truth",
+    content:
+      "Do not search for the truth — only cease to cherish opinions. The truth has been waiting in your kitchen the whole time.",
+    era: "Tang",
+    attributedMasterSlug: "jianzhi-sengcan",
+    collection: "Xinxinming",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Daman Hongren ───────────────────────────────────────────────────
+  {
+    slug: "proverb-hongren-guard-the-mind",
+    title: "Guard the One Mind",
+    content:
+      "Guard the one mind through all twelve hours of the day. The chickens scatter, the visitors come and go; if the one mind is guarded, none of them disturb the household.",
+    era: "Tang",
+    attributedMasterSlug: "daman-hongren",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  {
+    slug: "proverb-hongren-true-pearl",
+    title: "True Pearl in Muddy Water",
+    content:
+      "Stir the muddy water and the pearl is hidden. Sit still, and the mud settles, and the pearl appears — not because you have created it but because you have stopped disturbing it.",
+    era: "Tang",
+    attributedMasterSlug: "daman-hongren",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  {
+    slug: "proverb-hongren-shentou-shenxiu",
+    title: "Two Verses, One Field",
+    content:
+      "Shenxiu wrote of polishing the mirror. Huineng wrote that there is no mirror. The robe went south; the polishing did not stop. Both verses were correct, in different rooms of the same house.",
+    era: "Tang",
+    attributedMasterSlug: "daman-hongren",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mcrae_seeing_through_zen" }],
+  },
+  // ─── Qingyuan Xingsi ─────────────────────────────────────────────────
+  {
+    slug: "proverb-qingyuan-mountains-rivers",
+    title: "Mountains Are Mountains Again",
+    content:
+      "Before I studied Chan, mountains were mountains and rivers were rivers. After studying Chan, mountains were no longer mountains and rivers no longer rivers. Now, after thirty years, mountains are again mountains and rivers again rivers — but with fewer feet of mine in the way.",
+    era: "Tang",
+    attributedMasterSlug: "qingyuan-xingsi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-qingyuan-axe-handle",
+    title: "Cutting an Axe-Handle",
+    content:
+      "To cut an axe-handle, the model is in your hand. To pass on the dharma, the model is in your life. Look closely at the model; if it has a chip in it, the new handle will too.",
+    era: "Tang",
+    attributedMasterSlug: "qingyuan-xingsi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-qingyuan-no-marvels",
+    title: "No Marvels at the Hermitage",
+    content:
+      "There are no marvels at this hermitage. We sweep, we cook, we sit. If you wanted marvels, you should have gone to the city — they sell them cheap there, and they break before you reach home.",
+    era: "Tang",
+    attributedMasterSlug: "qingyuan-xingsi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-qingyuan-sound-of-grass",
+    title: "Sound of Grass",
+    content:
+      "If you cannot hear the sound of grass growing, you are not yet quiet enough. Sit until you hear it, and you will not be tempted to mistake your speech for teaching.",
+    era: "Tang",
+    attributedMasterSlug: "qingyuan-xingsi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Nanyue Huairang ─────────────────────────────────────────────────
+  {
+    slug: "proverb-nanyue-polish-tile",
+    title: "Polishing a Tile",
+    content:
+      "I polished a tile in front of him until he asked what I was doing. I said: making a mirror. He laughed: a tile cannot be polished into a mirror. I said: nor can sitting be polished into a Buddha — if you are sitting in order to become one.",
+    era: "Tang",
+    attributedMasterSlug: "nanyue-huairang",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-nanyue-cart-or-ox",
+    title: "Cart or Ox?",
+    content:
+      "If a cart is stuck, do you whip the cart or the ox? If you sit in order to make the body still and the mind goes on as before, you have whipped the cart and not the ox.",
+    era: "Tang",
+    attributedMasterSlug: "nanyue-huairang",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-nanyue-eight-years",
+    title: "Eight Years to Speak",
+    content:
+      "Mazu studied with me for eight years before I asked him a single question. The answer that came was already an old answer when it came. The eight years had not been spent on a question — they had been spent on the mouth.",
+    era: "Tang",
+    attributedMasterSlug: "nanyue-huairang",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  // ─── Mazu Daoyi ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-mazu-ordinary-mind-is-the-way",
+    title: "Ordinary Mind Is the Way",
+    content:
+      "What is the Way? Ordinary mind is the Way. What is ordinary mind? Hungry, eat. Tired, sleep. Foolishness arises only when we add anything else.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-shout-deafens",
+    title: "A Shout That Deafens",
+    content:
+      "I shouted at Baizhang, and his ears rang for three days. The shout was not punishment — it was the doorway. Three days of deafness is a small price for the silence that follows.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-not-mind-not-buddha",
+    title: "Not Mind, Not Buddha",
+    content:
+      "Yesterday I said: this very mind is Buddha. Today I say: not mind, not Buddha. The teaching shifts; the student who clings to either statement misses both.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-trample-buddha",
+    title: "Trample the Buddha",
+    content:
+      "When you walk through the gate, leave the Buddha outside. If you carry him in, he becomes a stone in your shoe.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-eighty-students",
+    title: "Eighty-Four Students",
+    content:
+      "I had eighty-four enlightened students, and not one of them taught the same thing. The dharma is wide enough to give each of them a different door, and narrow enough that all those doors open onto the same yard.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-wild-fox",
+    title: "Wild Fox",
+    content:
+      "If you say a great practitioner does not fall under cause and effect, you become a wild fox for five hundred lives. If you say he is not blind to cause and effect, the wild fox is freed at once. Watch the difference of one syllable.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  {
+    slug: "proverb-mazu-the-tile",
+    title: "The Tile and the Tile-Maker",
+    content:
+      "Nanyue polished a tile to make a mirror; I polished sitting to make a Buddha. He laughed; I laughed back. From that day, I sat for the sake of sitting, and a Buddha appeared without anyone making one.",
+    era: "Tang",
+    attributedMasterSlug: "mazu-daoyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_poceski_ordinary_mind" }],
+  },
+  // ─── Baizhang Huaihai ────────────────────────────────────────────────
+  {
+    slug: "proverb-baizhang-day-without-work",
+    title: "A Day Without Work",
+    content:
+      "A day without work is a day without food. When my disciples hid my tools, I sat at the table and pushed the bowl away. They returned the tools the next morning.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-baizhang-pure-rule",
+    title: "The Pure Rule",
+    content:
+      "I wrote down the rules of the monastery so that no master after me could be tempted to make himself a king. Read the rules; they will outlast my voice. The voice was only there to write them.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-baizhang-hoe-and-text",
+    title: "Hoe and Sutra Together",
+    content:
+      "Bring the sutra to the field, and the field to the sutra. The two were never apart; only our habits make them seem so.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-baizhang-three-pounds-of-flax",
+    title: "Three Pounds of Flax",
+    content:
+      "What is Buddha? Three pounds of flax. The student who finds this strange has not yet weighed his own questions.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-baizhang-fox-koan",
+    title: "Fox in the Audience",
+    content:
+      "An old man came to my talks for many years, sitting at the back. He told me he had been a wild fox for five hundred lives because of one wrong word. We buried the fox with monks' rites. The wrong word, properly answered, frees not only the answerer.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    collection: "Mumonkan, Case 2",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-baizhang-step-out",
+    title: "Step Out of the Doorway",
+    content:
+      "Stand in the doorway and the wind cannot enter. Step into the room and the wind cannot enter. Step out, and the room and the wind both pass through you.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-baizhang-extraordinary",
+    title: "What Is Extraordinary",
+    content:
+      "What is extraordinary? Sitting alone on the great peak. The peak does not feel extraordinary about itself; that is its secret.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-baizhang-wash-bowl",
+    title: "Wash Your Bowl",
+    content:
+      "After breakfast, what should I do? Wash your bowl. After washing the bowl, what should I do? Set it down. After setting it down, what should I do? You are already doing it.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-huaihai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Huangbo Xiyun ───────────────────────────────────────────────────
+  {
+    slug: "proverb-huangbo-emptiness-mind",
+    title: "Mind Is Empty Like Space",
+    content:
+      "The mind is like empty space — and yet it is full of every star. To find the stars, you do not need to leave the space; only to stop looking elsewhere.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    collection: "Transmission of Mind",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-huangbo-no-buddha-outside",
+    title: "Beyond the Mind, No Buddha",
+    content:
+      "There is no Buddha outside the mind. To search for a Buddha is to lose your Buddha. The search itself is the only thing in the way.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 3–28" }],
+  },
+  {
+    slug: "proverb-huangbo-pierce-bone",
+    title: "Cold Pierces the Bone",
+    content:
+      "If the cold did not pierce the bone, how would the plum blossom be so fragrant? Practice without difficulty is fragrance without flower.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-huangbo-strike-emperor",
+    title: "Striking the Emperor",
+    content:
+      "When the future emperor questioned me sloppily, I struck him with my staff. He went on to rule the empire; he never asked a sloppy question again. The staff has many jobs.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-huangbo-no-grades",
+    title: "No Grades Among Buddhas",
+    content:
+      "There are no grades among Buddhas; you are not closer or farther by years of sitting. The day you forget the question of distance, you have arrived.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 3–28" }],
+  },
+  {
+    slug: "proverb-huangbo-give-up-words",
+    title: "Give Up Words and Reach Beyond",
+    content:
+      "Give up words, give up thinking, and stretch out to the place where words and thinking cannot reach. There you will meet me — not as a teacher, but as the same hand you use to hold this cup.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-huangbo-six-realms-one-mind",
+    title: "Six Realms, One Mind",
+    content:
+      "Heaven, hell, animal, hungry ghost, human, demigod — six realms, one mind. The mind that wakes from one to the next is the same mind in different clothes.",
+    era: "Tang",
+    attributedMasterSlug: "huangbo-xiyun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 3–28" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-chan-2.ts
+++ b/scripts/data/proverbs/expansion-chan-2.ts
@@ -1,0 +1,476 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const CHAN_PROVERBS_PART_2: CuratedProverb[] = [
+  // ─── Linji Yixuan ────────────────────────────────────────────────────
+  {
+    slug: "proverb-linji-true-person",
+    title: "The True Person of No Rank",
+    content:
+      "There is a true person of no rank, always coming in and going out through the gate of the senses. Those who have not yet seen this person — look! Look!",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    collection: "Record of Linji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-meet-buddha-kill",
+    title: "Kill the Buddha, Kill the Patriarchs",
+    content:
+      "If you meet the Buddha on the road, kill the Buddha. If you meet a patriarch, kill the patriarch. Only by killing the images that walk in front of you do you free the original face that has been walking with you all along.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    collection: "Record of Linji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-four-shouts",
+    title: "Four Kinds of Shout",
+    content:
+      "Sometimes I shout like a king's sword. Sometimes like a lion crouching. Sometimes like a fishing pole probing the waters. Sometimes a shout that is not a shout. The student who learns to tell them apart is already half-free.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-host-and-guest",
+    title: "Four Relations of Host and Guest",
+    content:
+      "Sometimes the host examines the guest, sometimes the guest examines the host, sometimes guest and host examine each other, sometimes host and guest forget themselves. Be all four; do not become attached to any of them.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-do-not-borrow",
+    title: "Do Not Borrow Eyes",
+    content:
+      "Do not borrow the patriarchs' eyes. The eyes you have are already the patriarchs' eyes; the borrowing is what makes them seem someone else's.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-three-mysterious",
+    title: "Three Mysterious Gates",
+    content:
+      "In one phrase, three mysterious gates. In one mysterious gate, three essentials. In one essential, ten thousand returns. The student who insists on counting them does not pass through any of them.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-followers-of-the-way",
+    title: "Followers of the Way",
+    content:
+      "Followers of the Way: do not let yourself be turned by circumstances. Wherever you are, simply be the host. Then circumstances cannot help being true.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    collection: "Record of Linji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  {
+    slug: "proverb-linji-no-affair",
+    title: "No Affair to Take Up",
+    content:
+      "When there is no affair to take up, do not take one up. When there is one, take it up without leaning on it. Then your day's work and your day's idleness are equally Buddha-work.",
+    era: "Tang",
+    attributedMasterSlug: "linji-yixuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_welter_linji" }],
+  },
+  // ─── Zhaozhou Congshen ───────────────────────────────────────────────
+  {
+    slug: "proverb-zhaozhou-mu",
+    title: "Mu",
+    content:
+      "Does a dog have Buddha-nature? Mu. Three years on this one syllable, and the syllable will pour back through your life and rinse it clean.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    collection: "Mumonkan, Case 1",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-zhaozhou-wash-bowl",
+    title: "Have You Eaten? Wash Your Bowl",
+    content:
+      "A monk said: I have just entered the monastery; please instruct me. Have you eaten breakfast? Yes. Then go and wash your bowl. The monk woke up.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    collection: "Mumonkan, Case 7",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-zhaozhou-cypress-tree",
+    title: "Cypress Tree in the Garden",
+    content:
+      "What is the meaning of the patriarch's coming from the west? The cypress tree in the garden. Do not look elsewhere — there is no elsewhere.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    collection: "Mumonkan, Case 37",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-zhaozhou-tea",
+    title: "Have a Cup of Tea",
+    content:
+      "A new monk arrived; I told him to have a cup of tea. An old monk arrived; I told him to have a cup of tea. The temple steward asked: why the same answer? I told him to have a cup of tea.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-zhaozhou-three-pounds-flax",
+    title: "Three Pounds, One Mountain",
+    content:
+      "Some teacher said: three pounds of flax. Some teacher said: a dry shit-stick. I say: a stone bridge. Cross all three, and you arrive at the same village.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-zhaozhou-not-yet",
+    title: "Even Now, Not Yet",
+    content:
+      "I am eighty years old, and even now I have not finished my study. The day I finish, I will sit down and rest; until then, the work continues whether or not I am tired.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-zhaozhou-stone-bridge",
+    title: "The Stone Bridge",
+    content:
+      "I have heard about the famous stone bridge of Zhaozhou — but I see only a single log. The stone bridge crosses both donkeys and horses; the single log only crosses you.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-zhaozhou-old-buddha",
+    title: "Old Buddha, Old Cup",
+    content:
+      "What is Zhaozhou? An old Buddha. What is the old Buddha? An old cup. The cup is not less because it is old; tea fills it as it always did.",
+    era: "Tang",
+    attributedMasterSlug: "zhaozhou-congshen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Shitou Xiqian ───────────────────────────────────────────────────
+  {
+    slug: "proverb-shitou-grass-hut",
+    title: "Song of the Grass Hut",
+    content:
+      "I have built a grass hut in which there is nothing of value. After eating, I'm ready for a nap. When the world looks for me, I'm not here — though I never went anywhere.",
+    era: "Tang",
+    attributedMasterSlug: "shitou-xiqian",
+    collection: "Caoanke (Song of the Grass Hut)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-shitou-merging-difference",
+    title: "Merging of Difference and Sameness",
+    content:
+      "Brightness and darkness are like the front and back foot in walking. The light is not above the dark; both are needed for the next step.",
+    era: "Tang",
+    attributedMasterSlug: "shitou-xiqian",
+    collection: "Sandōkai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-shitou-stone-head",
+    title: "Stone Head",
+    content:
+      "They call me Stone Head. A stone has no opinion of itself, no preference for sun or rain, no plan for tomorrow. If only my students were as steady.",
+    era: "Tang",
+    attributedMasterSlug: "shitou-xiqian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-shitou-do-not-think-roof",
+    title: "Do Not Think About the Roof",
+    content:
+      "When sitting in your hut, do not think about whether the roof will leak. If it leaks, you will know. The thought beforehand only takes the place of the seat.",
+    era: "Tang",
+    attributedMasterSlug: "shitou-xiqian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-shitou-trickle-and-river",
+    title: "Trickle and River",
+    content:
+      "A trickle and a great river — the trickle does not envy the river, the river does not despise the trickle. Both flow downhill toward the same sea.",
+    era: "Tang",
+    attributedMasterSlug: "shitou-xiqian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  // ─── Dongshan Liangjie ───────────────────────────────────────────────
+  {
+    slug: "proverb-dongshan-five-ranks",
+    title: "Five Ranks of Lord and Vassal",
+    content:
+      "There is the apparent within the real; the real within the apparent; coming from within the real; arriving in mutual integration; arrival in unity. Five ranks, one lord — the names change, the lord does not.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    collection: "Five Ranks",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-dongshan-cold-kills",
+    title: "Where Cold Cannot Reach",
+    content:
+      "A monk asked: when cold and heat come, how can we escape them? Why not go to a place where there is no cold and no heat? Where is such a place? Where the cold kills you, the heat kills you.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    collection: "Book of Serenity, Case 43",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-dongshan-crossing-stream",
+    title: "Seeing My Reflection in the Stream",
+    content:
+      "Crossing the stream I saw my own face in the water — and there it was at last, looking back. He is exactly me, but I am not him; the meeting is the meaning.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-dongshan-no-stranger",
+    title: "Not a Stranger",
+    content:
+      "If you go to find this person, you will fail; the going makes him a stranger. Sit still where you are; soon he will sit down across from you, and you will not be able to tell which is the host.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-dongshan-snow-falls",
+    title: "Snow Falls into the Silver Bowl",
+    content:
+      "Snow falls into a silver bowl: the white touches the white, and yet it is two. So with the meeting of the apparent and the real — they are not one, and not two, and not somewhere in between.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    collection: "Jewel Mirror Samadhi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-dongshan-sickness",
+    title: "Last Sickness",
+    content:
+      "Even a sickness can be the teaching. When my last sickness came, my students wept. I said: this body is not yours to mourn. Mourn the day you cannot tell whose body it is.",
+    era: "Tang",
+    attributedMasterSlug: "dongshan-liangjie",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Caoshan Benji ───────────────────────────────────────────────────
+  {
+    slug: "proverb-caoshan-wine-of-jade",
+    title: "Wine of Jade",
+    content:
+      "There is a wine of jade in this house — invisible, scentless, intoxicating. The student who reaches for the cup misses it; the student who simply sits at the table is already drinking.",
+    era: "Tang",
+    attributedMasterSlug: "caoshan-benji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-caoshan-loyal-vassal",
+    title: "Loyal Vassal",
+    content:
+      "A loyal vassal speaks bluntly, even to the lord. So a real student answers his master plainly — the loyalty is in the bluntness, not in the bow.",
+    era: "Tang",
+    attributedMasterSlug: "caoshan-benji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-caoshan-five-positions-painting",
+    title: "Painting the Five Positions",
+    content:
+      "I drew circles for the five positions, partly black, partly white. A picture is only paint; the positions are in the way you stand up from the cushion.",
+    era: "Tang",
+    attributedMasterSlug: "caoshan-benji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_book_of_serenity" }],
+  },
+  {
+    slug: "proverb-caoshan-blind-donkey",
+    title: "Blind Donkey",
+    content:
+      "Beware of being a blind donkey, dragged by the lead. The lead is your own habit, dressed up as the dharma. Cut it, and the road is yours.",
+    era: "Tang",
+    attributedMasterSlug: "caoshan-benji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Yunmen Wenyan ───────────────────────────────────────────────────
+  {
+    slug: "proverb-yunmen-dry-shit-stick",
+    title: "Dry Shit-Stick",
+    content:
+      "What is Buddha? A dry shit-stick. The blunt phrase is the medicine for the polished mind.",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    collection: "Mumonkan, Case 21",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-yunmen-every-day-good-day",
+    title: "Every Day Is a Good Day",
+    content:
+      "What about before the fifteenth of the month? I will not ask. After the fifteenth? Every day is a good day. The good is not in the calendar but in the willingness to meet whatever shows up.",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    collection: "Blue Cliff Record, Case 6",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-yunmen-one-word",
+    title: "One-Word Barrier",
+    content:
+      "What is the dharma? Suitable. What is the practice? Through. What is the highest matter? Look. One word, one barrier; pass it, and you walk.",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_app_yunmen" }],
+  },
+  {
+    slug: "proverb-yunmen-three-statements",
+    title: "Three Statements of Yunmen",
+    content:
+      "A statement that meets heaven and earth; a statement that follows the waves; a statement that cuts off all streams. Use them in turn — never as a formula, always as a fit.",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_app_yunmen" }],
+  },
+  {
+    slug: "proverb-yunmen-bell-and-robe",
+    title: "Bell and Robe",
+    content:
+      "When the bell rings, why do you put on the seven-piece robe? The bell does not require the robe; the robe does not require the bell. Yet when the bell rings, the robe goes on. That is the practice.",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_app_yunmen" }],
+  },
+  {
+    slug: "proverb-yunmen-medicine-and-sickness",
+    title: "Medicine and Sickness Cure One Another",
+    content:
+      "Medicine and sickness cure one another. The whole earth is medicine; the whole earth is also sickness. Where is the patient?",
+    era: "Tang",
+    attributedMasterSlug: "yunmen-wenyan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_app_yunmen" }],
+  },
+  // ─── Deshan Xuanjian ─────────────────────────────────────────────────
+  {
+    slug: "proverb-deshan-burn-the-commentaries",
+    title: "Burning the Commentaries",
+    content:
+      "I carried my commentaries on the Diamond Sutra over the mountains; I burned them in front of the master's gate. The fire warmed my hands. The teaching has not needed a footnote since.",
+    era: "Tang",
+    attributedMasterSlug: "deshan-xuanjian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-deshan-thirty-blows",
+    title: "Thirty Blows",
+    content:
+      "If you can speak, thirty blows. If you cannot speak, thirty blows. Why? Because the blow is not punishment; it is the part of the teaching that words cannot take over.",
+    era: "Tang",
+    attributedMasterSlug: "deshan-xuanjian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-deshan-grandmother",
+    title: "Grandmother on the Road",
+    content:
+      "An old woman selling rice cakes asked me which mind I wished to refresh — past, present, or future? I had no answer; my commentaries were no use. From that day my mouth grew quieter.",
+    era: "Tang",
+    attributedMasterSlug: "deshan-xuanjian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-deshan-blow-out-candle",
+    title: "Blow Out the Candle",
+    content:
+      "Longtan blew out the candle as I left his room. My eyes were full of dark, and I bowed: the dark was the candle.",
+    era: "Tang",
+    attributedMasterSlug: "deshan-xuanjian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Xiangyan Zhixian ────────────────────────────────────────────────
+  {
+    slug: "proverb-xiangyan-tile-on-bamboo",
+    title: "Tile Striking the Bamboo",
+    content:
+      "Sweeping the path, a piece of tile struck the bamboo. The sound emptied my whole search of thirty years; I bowed in the direction of my old master and said: had he answered me then, I would never have arrived here.",
+    era: "Tang",
+    attributedMasterSlug: "xiangyan-zhixian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-xiangyan-up-tree",
+    title: "A Man Up a Tree",
+    content:
+      "A man hangs from a tree by his teeth. Hands cannot hold a branch, feet cannot reach a limb. Someone asks the meaning of the patriarch's coming from the west. If he opens his mouth, he loses his life. If he does not open it, he fails to answer. What does he do?",
+    era: "Tang",
+    attributedMasterSlug: "xiangyan-zhixian",
+    collection: "Mumonkan, Case 5",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-xiangyan-sweep-the-path",
+    title: "Sweep the Path",
+    content:
+      "Sweep the path. Sweep it again. Sweep it for thirty years. One day the broom will sweep the sweeper; and you will hear what tile-on-bamboo means without anyone striking either.",
+    era: "Tang",
+    attributedMasterSlug: "xiangyan-zhixian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-xiangyan-one-blow",
+    title: "One Blow Forgets All Previous Knowledge",
+    content:
+      "One blow, and all previous knowledge is forgotten. Then there is no need for tactics or rules; the body practices on its own; the day's work is enough.",
+    era: "Tang",
+    attributedMasterSlug: "xiangyan-zhixian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-chan-3.ts
+++ b/scripts/data/proverbs/expansion-chan-3.ts
@@ -1,0 +1,461 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const CHAN_PROVERBS_PART_3: CuratedProverb[] = [
+  // ─── Guishan Lingyou ─────────────────────────────────────────────────
+  {
+    slug: "proverb-guishan-cow-river",
+    title: "After Death, a Water Buffalo",
+    content:
+      "When this old monk dies, I will be reborn as a water buffalo at the foot of the mountain. The buffalo will have my name on its flank, and you will not be confused about who is teaching you.",
+    era: "Tang",
+    attributedMasterSlug: "guishan-lingyou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-guishan-broken-pot",
+    title: "Broken Pot",
+    content:
+      "A monk broke a clay pot at my door and apologized. I said: do not apologize to me; apologize to the pot for asking it to be a pot all those years.",
+    era: "Tang",
+    attributedMasterSlug: "guishan-lingyou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-guishan-mountain-life",
+    title: "A Lifetime on One Mountain",
+    content:
+      "Forty years on this mountain. The trees know me; the path knows me. The student who can stay on one mountain for a lifetime has already left it.",
+    era: "Tang",
+    attributedMasterSlug: "guishan-lingyou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-guishan-warning",
+    title: "Admonitions",
+    content:
+      "If you join this assembly, do not waste your robes. Idleness in robes is theft from the donor; sleep in robes is theft from yourself.",
+    era: "Tang",
+    attributedMasterSlug: "guishan-lingyou",
+    collection: "Guishan Jingce",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-guishan-great-and-small",
+    title: "Great and Small",
+    content:
+      "What is great is great in being small; what is small is small in being great. Do not measure the practice by the size of the temple.",
+    era: "Tang",
+    attributedMasterSlug: "guishan-lingyou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Yangshan Huiji ──────────────────────────────────────────────────
+  {
+    slug: "proverb-yangshan-circle-on-ground",
+    title: "Circle on the Ground",
+    content:
+      "I drew a circle on the ground; my master stood inside it. We could not have spoken any plainer with a thousand words.",
+    era: "Tang",
+    attributedMasterSlug: "yangshan-huiji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-yangshan-mountain-monastery",
+    title: "Where Are You From?",
+    content:
+      "A monk arrived. Where are you from? From the mountains. Which mountain? The student who answers any mountain has not yet been on it.",
+    era: "Tang",
+    attributedMasterSlug: "yangshan-huiji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-yangshan-sigil",
+    title: "Sigil and Letter",
+    content:
+      "Some teachers transmit by letters; my school transmits by sigils. The sigil is not pretty; it is meant to be unrepeatable, like the moment it was drawn.",
+    era: "Tang",
+    attributedMasterSlug: "yangshan-huiji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-yangshan-dharma-talk",
+    title: "Brief Dharma Talk",
+    content:
+      "Today's dharma talk: bow when you enter, bow when you leave, and try not to fall asleep in the middle. Tomorrow's dharma talk will be the same.",
+    era: "Tang",
+    attributedMasterSlug: "yangshan-huiji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-yangshan-everything-flowers",
+    title: "Everything Is the Flower",
+    content:
+      "When the master holds up the flower, the flower is the master. When the master sets it down, the master is the flower. The misunderstanding is to think only the holding-up counts.",
+    era: "Tang",
+    attributedMasterSlug: "yangshan-huiji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Wumen Huikai ────────────────────────────────────────────────────
+  {
+    slug: "proverb-wumen-mu-doubt",
+    title: "Concentrate on Mu",
+    content:
+      "Concentrate yourself into this Mu. Day and night without ceasing. When you reach the moment when concentrating itself drops, the gateless gate has opened.",
+    era: "Song",
+    attributedMasterSlug: "wumen-huikai",
+    collection: "Mumonkan, Case 1",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-wumen-bare-sword",
+    title: "Bare Sword",
+    content:
+      "Make your whole body into a great mass of doubt. Then bring out the sword called Mu. When the sword cuts cleanly, you cannot tell it from the cut.",
+    era: "Song",
+    attributedMasterSlug: "wumen-huikai",
+    licenseStatus: "public_domain",
+    citations: [{ sourceId: "src_mumonkan_senzaki_1934" }],
+  },
+  {
+    slug: "proverb-wumen-no-snowflake-here",
+    title: "No Snowflake Falls in the Wrong Place",
+    content:
+      "When the willow does not yet bend, the wind has not yet blown. Yet a single bend tells of the whole wind, and a single snowflake tells of the whole sky. Nothing is in the wrong place.",
+    era: "Song",
+    attributedMasterSlug: "wumen-huikai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 163–188" }],
+  },
+  {
+    slug: "proverb-wumen-paint-the-cake",
+    title: "A Painted Cake Will Not Satisfy Hunger",
+    content:
+      "A painted cake does not satisfy hunger. So the koan repeated to others does not feed the one who repeats it. Eat the cake yourself; the hunger does the rest.",
+    era: "Song",
+    attributedMasterSlug: "wumen-huikai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 163–188" }],
+  },
+  {
+    slug: "proverb-wumen-no-wonder-needed",
+    title: "No Wonder Is Needed",
+    content:
+      "If you tell me the rain has fallen, I do not need a wonder. The wonder is the rain. The wonder is also the telling.",
+    era: "Song",
+    attributedMasterSlug: "wumen-huikai",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_heine_wright_koan", pageOrSection: "pp. 163–188" }],
+  },
+  // ─── Yuanwu Keqin ────────────────────────────────────────────────────
+  {
+    slug: "proverb-yuanwu-jewel-mirror",
+    title: "Pivoting on the Jewel-Mirror",
+    content:
+      "All hundred koans pivot on the jewel-mirror. Each koan is a different angle of the same light; you do not need to collect them all to see what is shown.",
+    era: "Song",
+    attributedMasterSlug: "yuanwu-keqin",
+    collection: "Blue Cliff Record (Biyan Lu)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-yuanwu-pointer-and-verse",
+    title: "Pointer and Verse",
+    content:
+      "Xuedou wrote the verse. I add the pointer. The pointer is for the student who has not yet noticed where to look; the verse is for the student who has been looking too long.",
+    era: "Song",
+    attributedMasterSlug: "yuanwu-keqin",
+    collection: "Blue Cliff Record (Biyan Lu)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-yuanwu-incense-stick",
+    title: "Incense Stick on the Iron Anvil",
+    content:
+      "An incense stick struck against an iron anvil sends up no smoke worth speaking of. Yet a single sneeze in the meditation hall is talked about for years. Why? Because the sneeze was honest.",
+    era: "Song",
+    attributedMasterSlug: "yuanwu-keqin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-yuanwu-passing-on",
+    title: "Passing On",
+    content:
+      "I passed the dharma to Dahui as one passes a lit candle in a windy hall. The candle does not belong to me, and once it is lit in his hand, it does not belong to him either.",
+    era: "Song",
+    attributedMasterSlug: "yuanwu-keqin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-yuanwu-pivot",
+    title: "Pivot Word",
+    content:
+      "There is a pivot word at the heart of every koan. Find it, and the rest of the case turns easily. Miss it, and the case becomes a stone in your pocket.",
+    era: "Song",
+    attributedMasterSlug: "yuanwu-keqin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  // ─── Dahui Zonggao ───────────────────────────────────────────────────
+  {
+    slug: "proverb-dahui-burn-the-record",
+    title: "Burning the Blue Cliff Record",
+    content:
+      "I burned the wood-blocks of my master's record because students were memorizing the cases instead of meeting them. The fire that destroyed the book preserved the dharma.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-dahui-against-silent-illumination",
+    title: "Against Mere Silent Illumination",
+    content:
+      "Some teachers tell you to sit until the mind is bright like a clear pond. I tell you: bring up the hwadu and let it cut through the pond. A pond untouched by a stone does not yet show its bottom.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-dahui-letters",
+    title: "Letters to Lay Students",
+    content:
+      "I write to officials and merchants the same way I speak to monks. The dharma is not embarrassed by the marketplace; the marketplace is the place where it is most needed.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    collection: "Letters of Dahui",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-dahui-doubt-mass",
+    title: "Great Mass of Doubt",
+    content:
+      "Stir up a great mass of doubt about the hwadu. Stir until the doubt becomes the only thing in your day. The day the doubt cracks, the day cracks too.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-dahui-laypeople",
+    title: "Householders Practice Hardest",
+    content:
+      "The householder's practice is the hardest. Children cry, debts arrive, work waits. Nobody rings a bell to begin or end. Whoever practices well in this is already an old master.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  {
+    slug: "proverb-dahui-not-quietude",
+    title: "Quietude Is Not the Goal",
+    content:
+      "If quietude were the goal, every stone would be a Buddha. Quietude is the chair the practice sits in; it is not the practice itself.",
+    era: "Song",
+    attributedMasterSlug: "dahui-zonggao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_schlutter_dahui" }],
+  },
+  // ─── Xuedou Chongxian ────────────────────────────────────────────────
+  {
+    slug: "proverb-xuedou-snowy-cliff",
+    title: "Snowy Cliff",
+    content:
+      "I sit on a snowy cliff and write verses for old cases. The cases are old; the snow is new. The two are arranged so that you cannot read one without seeing the other.",
+    era: "Song",
+    attributedMasterSlug: "xuedou-chongxian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-xuedou-hundred-cases",
+    title: "Hundred Cases, Hundred Verses",
+    content:
+      "I selected one hundred cases and wrote one hundred verses. The reader who runs through them in a day has read nothing. Sit with one for a year, and the other ninety-nine open.",
+    era: "Song",
+    attributedMasterSlug: "xuedou-chongxian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-xuedou-poet-monk",
+    title: "Poet-Monk",
+    content:
+      "Some say I am too much a poet to be a real Chan master. The Chan that fits inside a poem fits everywhere. The Chan that does not is too small to be the dharma.",
+    era: "Song",
+    attributedMasterSlug: "xuedou-chongxian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-xuedou-only-one-thing",
+    title: "Only One Thing to Settle",
+    content:
+      "Settle this one thing, and the ten thousand affairs settle themselves. Refuse to settle it, and the ten thousand affairs become ten thousand small stones in your shoe.",
+    era: "Song",
+    attributedMasterSlug: "xuedou-chongxian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  {
+    slug: "proverb-xuedou-cold-pond",
+    title: "Cold Pond and Bright Moon",
+    content:
+      "The cold pond and the bright moon — neither is master, neither is guest. They simply meet, and the meeting is enough. Practice is the same.",
+    era: "Song",
+    attributedMasterSlug: "xuedou-chongxian",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_blue_cliff_record_shaw_1961" }],
+  },
+  // ─── Hongzhi Zhengjue ────────────────────────────────────────────────
+  {
+    slug: "proverb-hongzhi-silent-illumination",
+    title: "Silent Illumination",
+    content:
+      "Sitting silently, the mind illumines without reaching. Illuminating without reaching, the world arises in the silence — not added on, not pushed away.",
+    era: "Song",
+    attributedMasterSlug: "hongzhi-zhengjue",
+    collection: "Cultivating the Empty Field",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-hongzhi-empty-field",
+    title: "Empty Field",
+    content:
+      "Cultivate the empty field. Do not till it; do not seed it; do not weed it. Yet from the empty field, every grain of rice we eat at this monastery has come.",
+    era: "Song",
+    attributedMasterSlug: "hongzhi-zhengjue",
+    collection: "Cultivating the Empty Field",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-hongzhi-wide-pond",
+    title: "Wide Pond, Single Reed",
+    content:
+      "A wide pond and a single reed at its edge — that is the proper proportion of the meditation hall. Too many reeds and the pond is hidden; too wide a pond and the reed is forgotten.",
+    era: "Song",
+    attributedMasterSlug: "hongzhi-zhengjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-hongzhi-do-not-grasp-stillness",
+    title: "Do Not Grasp Stillness",
+    content:
+      "If you sit and grasp at stillness, the stillness becomes another form of activity. Sit and let stillness arrive; do not invite it; do not refuse it; serve it tea when it comes.",
+    era: "Song",
+    attributedMasterSlug: "hongzhi-zhengjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  {
+    slug: "proverb-hongzhi-bright-moon",
+    title: "Moon and Pond",
+    content:
+      "When the bright moon enters the pond, the pond is not deeper for it. When the moon leaves, the pond is not shallower. The pond's practice is to receive without recording.",
+    era: "Song",
+    attributedMasterSlug: "hongzhi-zhengjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_leighton_cultivating_empty_field" }],
+  },
+  // ─── Foyan Qingyuan ──────────────────────────────────────────────────
+  {
+    slug: "proverb-foyan-instant-zen",
+    title: "Now Is the Instant",
+    content:
+      "Practice cannot be saved for tomorrow. Even today is too late if you wait until evening. Now is the instant — the only one available.",
+    era: "Song",
+    attributedMasterSlug: "foyan-qingyuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-foyan-do-not-cling",
+    title: "Do Not Cling to the Moment",
+    content:
+      "If you cling to this moment, it becomes a moment ago and you have already missed it. Hold it loose enough that the next one finds your hand still open.",
+    era: "Song",
+    attributedMasterSlug: "foyan-qingyuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-foyan-not-yet-spoken",
+    title: "What Has Not Yet Been Spoken",
+    content:
+      "The most important sentence in the dharma has not yet been spoken — and it is being spoken now. The student who waits for the famous sentences will hear only the echoes.",
+    era: "Song",
+    attributedMasterSlug: "foyan-qingyuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-foyan-iron-mountain",
+    title: "Iron Mountain Pass",
+    content:
+      "There is an iron mountain pass through which the patriarchs walked. From a distance, the pass looks impossible; up close, the road runs straight through. The fear was the only obstacle.",
+    era: "Song",
+    attributedMasterSlug: "foyan-qingyuan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  // ─── Yongjia Xuanjue ─────────────────────────────────────────────────
+  {
+    slug: "proverb-yongjia-overnight-guest",
+    title: "Overnight Guest",
+    content:
+      "I came to Huineng for confirmation; we spoke a single night and I was confirmed. They have called me the Overnight Guest ever since. The night was long because nothing was held back.",
+    era: "Tang",
+    attributedMasterSlug: "yongjia-xuanjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-yongjia-walking-is-zen",
+    title: "Walking Is Zen, Sitting Is Zen",
+    content:
+      "Walking is Zen, sitting is Zen. Speaking and silent, moving and still — the body's nature stands serene, even in rough country.",
+    era: "Tang",
+    attributedMasterSlug: "yongjia-xuanjue",
+    collection: "Song of Realizing the Way (Zhengdaoge)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-yongjia-dragon-girl",
+    title: "Dragon Girl Becomes Buddha",
+    content:
+      "The dragon girl became Buddha in a single moment. The patriarchs took many lifetimes. Both stories are true; both are reminders not to keep score.",
+    era: "Tang",
+    attributedMasterSlug: "yongjia-xuanjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-yongjia-mind-is-the-faculty",
+    title: "Mind Is the Faculty, Things Are the Object",
+    content:
+      "Mind is the faculty, things are the object — like two knife blades striking sparks. To stop the sparks, do not put away the knives; learn the angle.",
+    era: "Tang",
+    attributedMasterSlug: "yongjia-xuanjue",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-extra.ts
+++ b/scripts/data/proverbs/expansion-extra.ts
@@ -1,0 +1,164 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+/**
+ * Top-up entries to satisfy regional minima:
+ *   – Japanese Zen ≥ 80 (additional Dōgen, Hakuin, Bankei, Ryōkan-style)
+ *   – Vietnamese Thiền ≥ 30 (additional Trúc Lâm voices)
+ *   – Tang/Song Chan extra masters with sparse coverage
+ */
+export const EXTRA_PROVERBS: CuratedProverb[] = [
+  // ─── Japanese top-up ─────────────────────────────────────────────────
+  {
+    slug: "proverb-dogen-painted-rice-cake",
+    title: "Painted Rice Cake",
+    content:
+      "Without painted rice cakes, there is no remedy for hunger. The image of awakening is not opposed to awakening; the painting and the eating belong to one kitchen.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Gabyō",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-mountains-rivers-sutra",
+    title: "Mountains and Rivers Sutra",
+    content:
+      "The blue mountains, the running rivers — these are not the setting for the sutra. They are the sutra. Those who can read in this way do not need a printed page.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-hakuin-young-monks",
+    title: "Letter to Young Monks",
+    content:
+      "Sit in the burning house and do not run. The flames will become the wind that fans your practice. The student who runs out has only escaped a fire that was about to teach.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-keizan-women-and-children",
+    title: "Women and Children Sit Too",
+    content:
+      "Whenever I built a hall, I made sure the women and children could sit there. The dharma had no robe of its own; it accepted any size.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-bankei-old-woman",
+    title: "Old Woman in the Audience",
+    content:
+      "An old woman heard one of my talks and went home and began to practice in her kitchen. Years later her son told me she had become a Buddha there. I never knew her name; the dharma did.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bassui-do-not-fear-doubt",
+    title: "Do Not Fear Doubt",
+    content:
+      "Doubt is the lamp; certainty is the candlestick. Without the lamp, the candlestick is decorative. Without the candlestick, the lamp burns the floor. Carry both.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Vietnamese top-up ───────────────────────────────────────────────
+  {
+    slug: "proverb-tnh-walking-with-buddha",
+    title: "Walking with the Buddha",
+    content:
+      "When you walk, walk as though the Buddha walks with you. After many walks, you will notice that the Buddha walks because you do — and that he never had any other legs.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  {
+    slug: "proverb-tnh-tea-ceremony",
+    title: "Drinking Tea",
+    content:
+      "Drink your tea slowly and reverently, as if it is the axis on which the world turns — slowly, evenly, without rushing toward the future. Live the actual moment; only this moment is life.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  {
+    slug: "proverb-tran-nhan-tong-after-throne",
+    title: "After the Throne",
+    content:
+      "After leaving the throne I lived in the mountains, and many came to ask for guidance. I told them: do as I did, but in your own house. Whatever throne you sit upon, leave it daily — and return to it in service.",
+    era: "Trần Dynasty",
+    attributedMasterSlug: "tran-nhan-tong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_le_manh_that" }],
+  },
+  // ─── Sparse-coverage Chan masters (extra coverage) ───────────────────
+  {
+    slug: "proverb-baizhang-niepan-nirvana-name",
+    title: "Nirvana, a Name",
+    content:
+      "Nirvana is a name. Do not put on the name as a robe. Sit in the body that wears no name, and you will find what the word was pointing to.",
+    era: "Tang",
+    attributedMasterSlug: "baizhang-niepan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-fayan-wenyi-six-attributes",
+    title: "Six Attributes of One House",
+    content:
+      "Universal and particular, identical and different, integration and disintegration — six attributes of one house. The student who lives in the house need not name them; the rooms work whether or not he has the words.",
+    era: "Tang",
+    attributedMasterSlug: "fayan-wenyi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-fenyang-shanzhao-three-statements",
+    title: "Three Statements of Fenyang",
+    content:
+      "When the host is the host, the guest is the guest. When the host is the guest, the guest is the host. When neither is host nor guest, dinner has begun.",
+    era: "Song",
+    attributedMasterSlug: "fenyang-shanzhao",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-wuzu-fayan-letter-to-yuanwu",
+    title: "Wuzu's Encouragement",
+    content:
+      "I told Yuanwu: do not measure your awakening against another's. Each awakening is a particular voice; the chorus only sings if every voice keeps its own pitch.",
+    era: "Song",
+    attributedMasterSlug: "wuzu-fayan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_ferguson_zen_chinese_heritage" }],
+  },
+  {
+    slug: "proverb-tiantong-rujing-shed-body",
+    title: "Body and Mind Drop Away",
+    content:
+      "Body and mind drop away — that is the practice. The student who tries to drop them on purpose finds them stuck more firmly. Sit until the body forgets itself; the rest is automatic.",
+    era: "Song",
+    attributedMasterSlug: "tiantong-rujing",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-tiantong-rujing-do-not-burn-incense",
+    title: "Do Not Burn Incense for Show",
+    content:
+      "Do not burn incense for show, do not bow for show, do not chant for show. The dharma does not need an audience; you need a few honest mornings.",
+    era: "Song",
+    attributedMasterSlug: "tiantong-rujing",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-indian.ts
+++ b/scripts/data/proverbs/expansion-indian.ts
@@ -1,0 +1,378 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const INDIAN_PROVERBS: CuratedProverb[] = [
+  // ─── Mahākāśyapa ─────────────────────────────────────────────────────
+  {
+    slug: "proverb-mahakashyapa-flower-smile",
+    title: "Flower and Smile",
+    content:
+      "On Vulture Peak the World-Honored One held up a flower; the assembly was silent; only Mahākāśyapa smiled. The flower has not stopped being held up; the smile has not stopped traveling.",
+    era: "Pre-Han",
+    attributedMasterSlug: "mahakashyapa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-mahakashyapa-twirl-flower",
+    title: "Why Mahākāśyapa Smiled",
+    content:
+      "He smiled not because he understood, but because there was nothing left to misunderstand. To smile in that way once is to have transmission already.",
+    era: "Pre-Han",
+    attributedMasterSlug: "mahakashyapa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-mahakashyapa-three-robes",
+    title: "Three Robes and a Bowl",
+    content:
+      "Three robes and a bowl are enough for a monk. If you cannot live within those four objects, no fifth object will save you.",
+    era: "Pre-Han",
+    attributedMasterSlug: "mahakashyapa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  {
+    slug: "proverb-mahakashyapa-ascetic-discipline",
+    title: "Ascetic Discipline",
+    content:
+      "Some called my discipline severe. I never asked the body for more than the body could give; I asked it not to bargain. The bargaining is the only severe thing.",
+    era: "Pre-Han",
+    attributedMasterSlug: "mahakashyapa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  {
+    slug: "proverb-mahakashyapa-first-council",
+    title: "First Council",
+    content:
+      "After the World-Honored One died, we gathered to remember his words. Memory was the first sangha; the rules were a fence around the memory; the practice was the field inside the fence.",
+    era: "Pre-Han",
+    attributedMasterSlug: "mahakashyapa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  // ─── Ānanda ──────────────────────────────────────────────────────────
+  {
+    slug: "proverb-ananda-thus-have-i-heard",
+    title: "Thus Have I Heard",
+    content:
+      "Every sutra begins: thus have I heard. I was the one who heard. Memory is the first ferry; do not curse the ferryman.",
+    era: "Pre-Han",
+    attributedMasterSlug: "ananda",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  {
+    slug: "proverb-ananda-women-as-equals",
+    title: "Women as Equals",
+    content:
+      "I asked the World-Honored One whether women could awaken as men do. He said: yes. I asked again, in case he had not heard me. He said: yes again. The dharma did not need a third asking — but the world did.",
+    era: "Pre-Han",
+    attributedMasterSlug: "ananda",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  {
+    slug: "proverb-ananda-knock-down-pole",
+    title: "Knock Down the Pole",
+    content:
+      "Mahākāśyapa told me: knock down the pole at the gate. I did so, and only then was I admitted to the council. The robe and the memorizing were not enough; the gate too had to be released.",
+    era: "Pre-Han",
+    attributedMasterSlug: "ananda",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-ananda-attendant",
+    title: "Twenty-Five Years as Attendant",
+    content:
+      "I was the World-Honored One's attendant for twenty-five years. The dharma I learned was not in the talks I overheard; it was in the way the bowl was washed after each meal.",
+    era: "Pre-Han",
+    attributedMasterSlug: "ananda",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  {
+    slug: "proverb-ananda-late-arahant",
+    title: "Late Arahantship",
+    content:
+      "I attained arahantship the night before the council, after years of being told I was not yet ready. Whoever has been told he is not ready: that telling itself is the door.",
+    era: "Pre-Han",
+    attributedMasterSlug: "ananda",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_rhys_davids_buddhist_suttas_1881" }],
+  },
+  // ─── Nāgārjuna ───────────────────────────────────────────────────────
+  {
+    slug: "proverb-nagarjuna-emptiness-is-medicine",
+    title: "Emptiness Is the Medicine",
+    content:
+      "If you grasp emptiness as a thing, the medicine becomes a sickness. The Buddha gave emptiness as the medicine for all views; do not let it become another view.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-nagarjuna-two-truths",
+    title: "Two Truths",
+    content:
+      "There is conventional truth and there is ultimate truth. Without the conventional, the ultimate cannot be taught; without the ultimate, the conventional becomes a prison. Walk on both feet.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-nagarjuna-no-coming-no-going",
+    title: "Eight Negations",
+    content:
+      "No arising, no ceasing; no permanence, no annihilation; no coming, no going; no one, no many. From this eightfold no, the world arises freshly each instant.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    collection: "Mūlamadhyamakakārikā",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-nagarjuna-snake-and-rope",
+    title: "Snake and Rope",
+    content:
+      "In the dim light, the rope looked like a snake. Once the lamp was brought, neither the snake nor the rope was as you had supposed. Bring the lamp, and your problems re-introduce themselves.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-nagarjuna-friendly-letter",
+    title: "Friendly Letter to a King",
+    content:
+      "I wrote to a king: rule with patience as if the kingdom were your own body, and not as if your body were the kingdom. The king who confuses these orders ends up wounded by his own taxes.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    collection: "Suhṛllekha",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-nagarjuna-without-thesis",
+    title: "Without a Thesis of My Own",
+    content:
+      "I have no thesis of my own. I take up your thesis, follow it through, and let it dissolve at its own end. Whoever calls me a teacher of nothing has heard me correctly.",
+    era: "Indic",
+    attributedMasterSlug: "nagarjuna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Vasubandhu ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-vasubandhu-thirty-verses",
+    title: "Thirty Verses on Consciousness",
+    content:
+      "Mind makes the world; the world makes the mind. Stand at the seam of these two, and the whole loom shows itself.",
+    era: "Indic",
+    attributedMasterSlug: "vasubandhu",
+    collection: "Triṃśikā",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-vasubandhu-changed-his-mind",
+    title: "Changed His Mind",
+    content:
+      "I taught the doctrine of one school for thirty years and then changed my mind. The students who refused to change with me lost more than I did.",
+    era: "Indic",
+    attributedMasterSlug: "vasubandhu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-vasubandhu-storehouse-consciousness",
+    title: "Storehouse Consciousness",
+    content:
+      "The seeds of all your acts are stored in a hidden room of the mind. Each act planted today is a fruit you will eat tomorrow — be careful what you sow even when no one is looking.",
+    era: "Indic",
+    attributedMasterSlug: "vasubandhu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-vasubandhu-three-natures",
+    title: "Three Natures",
+    content:
+      "The imagined, the dependent, the perfected — three natures of one experience. The imagined hides the dependent; the dependent hides the perfected; remove the imagined, and the rest is already shining.",
+    era: "Indic",
+    attributedMasterSlug: "vasubandhu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Aśvaghoṣa ───────────────────────────────────────────────────────
+  {
+    slug: "proverb-ashvaghosha-life-of-buddha",
+    title: "Life of the Buddha",
+    content:
+      "I wrote the life of the Buddha as a poet. Whoever reads only the doctrine misses the body of the man who carried it; whoever reads only the man misses the doctrine he carried.",
+    era: "Indic",
+    attributedMasterSlug: "ashvaghosha",
+    collection: "Buddhacarita",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-ashvaghosha-awakening-faith",
+    title: "Awakening of Faith",
+    content:
+      "Faith is not belief in a thing; faith is the willingness to keep sitting when the belief in sitting has gone. The dharma waits for the second kind.",
+    era: "Indic",
+    attributedMasterSlug: "ashvaghosha",
+    collection: "Awakening of Faith in the Mahāyāna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-ashvaghosha-poet-and-monk",
+    title: "Poet and Monk",
+    content:
+      "The poet hopes for a perfect verse and grieves the imperfect one. The monk practices the imperfect verse and lets the perfect one go.",
+    era: "Indic",
+    attributedMasterSlug: "ashvaghosha",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Āryadeva ────────────────────────────────────────────────────────
+  {
+    slug: "proverb-aryadeva-four-hundred-stanzas",
+    title: "Four Hundred Stanzas",
+    content:
+      "First I refute the wrong views; then I plant the right; then I let go of the right view too. Without the third step, the second is just another wrong view in disguise.",
+    era: "Indic",
+    attributedMasterSlug: "aryadeva",
+    collection: "Catuḥśataka",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-aryadeva-debate",
+    title: "Debate Without Pride",
+    content:
+      "Win the debate, and the dharma loses. Lose the debate, and the dharma loses. Sit in the debate without preference, and the dharma stands up at the end and walks home.",
+    era: "Indic",
+    attributedMasterSlug: "aryadeva",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-aryadeva-clear-water",
+    title: "Clear Water Holds the Sky",
+    content:
+      "Clear water holds the sky without effort. Stir it, and the sky breaks into pieces. Practice is the not-stirring.",
+    era: "Indic",
+    attributedMasterSlug: "aryadeva",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Prajñātara, Punyamitra, Buddhamitra (lineage patriarchs) ───────
+  {
+    slug: "proverb-prajnatara-no-need-to-recite",
+    title: "No Need to Recite",
+    content:
+      "Other monks recited the sutras at the donor's house; I sat. The donor asked: why do you not recite? I answered: when I breathe in, I do not consort with the world of beings; when I breathe out, I do not consort with the world of senses. So am I always reciting the sutra of all the buddhas.",
+    era: "Indic",
+    attributedMasterSlug: "prajnatara",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-prajnatara-train-bodhidharma",
+    title: "Send Bodhidharma North",
+    content:
+      "Sixty years after I am gone, you will go to a country to the north. Do not stay in our temple; the dharma in this place is well kept and needs no more keeping. The country to the north needs you more than we do.",
+    era: "Indic",
+    attributedMasterSlug: "prajnatara",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-prajnatara-no-pride-of-lineage",
+    title: "No Pride of Lineage",
+    content:
+      "I am the twenty-seventh patriarch only because someone wrote it down. The number does not bow when I bow; it does not eat when I eat; it has nothing to do with the sitting.",
+    era: "Indic",
+    attributedMasterSlug: "prajnatara",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-punyamitra-walk-not-talk",
+    title: "Walk, Do Not Talk",
+    content:
+      "I walked a long way for this dharma; I do not propose to talk it back into a cage. Whoever wants to know what I know should walk too.",
+    era: "Indic",
+    attributedMasterSlug: "punyamitra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-punyamitra-old-age",
+    title: "Old Age Teaches by Itself",
+    content:
+      "Old age teaches by itself if you let it. Do not race against your wrinkles; let them be the third teacher in the room, after your master and your hut.",
+    era: "Indic",
+    attributedMasterSlug: "punyamitra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-punyamitra-do-not-pity",
+    title: "Do Not Pity Yourself",
+    content:
+      "Self-pity is the sickness that disguises itself as the cure. Cut it cleanly; you will be surprised how light the body becomes when you are no longer carrying yourself.",
+    era: "Indic",
+    attributedMasterSlug: "punyamitra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-buddhamitra-find-the-old-king",
+    title: "Find the Old King",
+    content:
+      "I told my disciple: there is a son of an old king walking in the marketplace, and he does not yet know who he is. Find him; remind him; and the kingdom is reset by a single sentence.",
+    era: "Indic",
+    attributedMasterSlug: "buddhamitra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-buddhamitra-old-and-young",
+    title: "Old and Young",
+    content:
+      "An old monk and a young monk study the same dharma differently. The old monk has less time; the young monk has less hurry. Both must learn the other's gift.",
+    era: "Indic",
+    attributedMasterSlug: "buddhamitra",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  // ─── Upagupta ────────────────────────────────────────────────────────
+  {
+    slug: "proverb-upagupta-counted-stones",
+    title: "Counted Stones",
+    content:
+      "I asked each new student to bring a small stone for every passion that arose. The cave filled with stones; the passions did not. Then we built a wall around the cave with the stones, and used it as a meditation hall.",
+    era: "Indic",
+    attributedMasterSlug: "upagupta",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+  {
+    slug: "proverb-upagupta-lay-merchant",
+    title: "Lay Merchant Awakens",
+    content:
+      "A wealthy merchant came to me wanting to leave the world. I told him: stay in the world and trade fairly; the dharma is in the weighing of the goods. He returned a year later and said: the scales have been my master.",
+    era: "Indic",
+    attributedMasterSlug: "upagupta",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dt_suzuki_essays_1927" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-japanese.ts
+++ b/scripts/data/proverbs/expansion-japanese.ts
@@ -1,0 +1,627 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const JAPANESE_PROVERBS: CuratedProverb[] = [
+  // ─── Dōgen ───────────────────────────────────────────────────────────
+  {
+    slug: "proverb-dogen-time-being",
+    title: "The Time-Being",
+    content:
+      "Time is the thing, and the thing is time. The pine is time; the bamboo is time. To say I am wasting time is to admit you are waiting for time to be elsewhere; it never is.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Uji",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-firewood-and-ash",
+    title: "Firewood Does Not Become Ash",
+    content:
+      "Firewood does not become ash. Firewood is firewood completely; ash is ash completely. To say one becomes the other is to step over the moment in which each one stands alone.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Genjokoan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-fish-bird",
+    title: "Fish in Water, Bird in Sky",
+    content:
+      "When the fish swims, the water has no edges for the fish; when the bird flies, the sky has no edges for the bird. Each fully fills its element. So we, when we sit, fill the sitting.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Genjokoan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-just-sit",
+    title: "Just Sit (Shikantaza)",
+    content:
+      "Sit without a single goal. If a goal sneaks in, sit with the goal as another visitor. The sitting that has no purpose is the sitting that completes its purpose.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Fukan-zazengi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-mountains-walking",
+    title: "Mountains Walking",
+    content:
+      "Mountains are walking. Those who do not see this say: how could a mountain walk? Those who see it say: how could a mountain not walk?",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Sansuikyo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-instructions-cook",
+    title: "Instructions to the Cook",
+    content:
+      "When you wash the rice, do not separate the work from yourself. Do not separate yourself from the work. Cook with great mind, parental mind, joyful mind. The meal is the dharma; you are the menu.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Tenzo Kyokun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-flowers-fall",
+    title: "Flowers Fall, Weeds Spring",
+    content:
+      "Flowers fall amid our longing; weeds spring up amid our aversion. Both belong to the same garden, and the garden does not consult us about its arrangement.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    collection: "Shobogenzo, Genjokoan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  {
+    slug: "proverb-dogen-monk-priest",
+    title: "Body and Mind Falling Away",
+    content:
+      "Body and mind fall away; fallen-away body and mind. The student who hears this and sets out to make body and mind fall away has reattached them with both hands.",
+    era: "Kamakura",
+    attributedMasterSlug: "dogen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kim_dogen" }],
+  },
+  // ─── Hakuin Ekaku ────────────────────────────────────────────────────
+  {
+    slug: "proverb-hakuin-one-hand-clapping",
+    title: "Sound of One Hand",
+    content:
+      "What is the sound of one hand clapping? Listen until the listening becomes the only sound in the room.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-great-doubt",
+    title: "Great Doubt, Great Awakening",
+    content:
+      "If your doubt is great, your awakening will be great. If your doubt is small, your awakening will be small. If you do not doubt at all, you will not awaken at all.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-soft-butter",
+    title: "Soft-Butter Method",
+    content:
+      "When the body grows ill from too-tight practice, place an imagined ball of soft butter on the crown of the head. Let it melt down through every joint and organ. The body returns; the practice continues without breaking the body it depends on.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    collection: "Yasen Kanna",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-is-that-so",
+    title: "Is That So?",
+    content:
+      "When the village accused me of fathering the child, I said: is that so? When they brought the child for me to raise, I said: is that so? When they came years later to apologize, I said: is that so? The dharma was not different in any of the three rooms.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-frog-koan",
+    title: "Frog of Hakuin",
+    content:
+      "Sit with such concentration that even a frog is your teacher. The frog jumps when it must; you sit when you must; the koan is the same in both.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-laypeople-can-too",
+    title: "Laypeople Can Awaken Too",
+    content:
+      "Some say only monks awaken. I have known farmers, weavers, and an old fishwife who saw their nature without ever entering a monastery. Whoever doubts greatly awakens greatly — robes are no shortcut.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-after-satori",
+    title: "After Satori, More Practice",
+    content:
+      "After the great awakening, the practice does not stop. It continues for the rest of one's life — but now it is the practice of being grateful, not the practice of catching up.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  {
+    slug: "proverb-hakuin-hell-is-self",
+    title: "Hell Is Made of Self",
+    content:
+      "Whoever has not seen self-nature has not yet escaped hell. Hell is not a place beneath the world; it is the room of self, and the door opens inward.",
+    era: "Edo",
+    attributedMasterSlug: "hakuin-ekaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_waddell_hakuin" }],
+  },
+  // ─── Bankei Yōtaku ───────────────────────────────────────────────────
+  {
+    slug: "proverb-bankei-do-not-fight-anger",
+    title: "Do Not Fight the Anger",
+    content:
+      "Do not fight the anger that arises. Do not water it; do not feed it; do not push it away. The Unborn buddha-mind does the rest while you sit still.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bankei-no-rules",
+    title: "No Special Rules",
+    content:
+      "I make no special rules for my students. Live as you live; only do not separate yourself from the Unborn. When the bell rings, come; when it is time to leave, go.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bankei-ordinary-language",
+    title: "Plain Words for Ordinary People",
+    content:
+      "I speak the dharma in plain Japanese, not borrowed Chinese. The dharma is not a foreign letter you must memorize; it is your own grandmother's tongue, used carefully.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bankei-quarrelsome-monk",
+    title: "Quarrelsome Monk",
+    content:
+      "A monk came to me complaining that he could not stop quarreling. I said: bring me your quarrel-mind, and I will sit on it. He could not find it. I told him: when next it arises, neither push nor cling — and you will find it has no resting place to be.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bankei-do-not-borrow-anguish",
+    title: "Do Not Borrow Anguish",
+    content:
+      "If anguish does not arise from this moment, do not borrow it from the past. Memory is a useful servant; do not let it become the master of the meditation hall.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  {
+    slug: "proverb-bankei-snoring-monks",
+    title: "Snoring Monks",
+    content:
+      "Some teachers strike snoring monks with the kyosaku. I let them snore — the body needs sleep, and the Unborn does not mind a snore. The next morning, the monk who slept practices freshly.",
+    era: "Edo",
+    attributedMasterSlug: "bankei-yotaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_haskel_bankei" }],
+  },
+  // ─── Ikkyū Sōjun ─────────────────────────────────────────────────────
+  {
+    slug: "proverb-ikkyu-attention",
+    title: "Attention. Attention.",
+    content:
+      "A pilgrim asked me to write a single phrase of the highest wisdom. I wrote: Attention. He said: that is all? I wrote: Attention, Attention. He said: but they look the same. I wrote: Attention, Attention, Attention.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  {
+    slug: "proverb-ikkyu-skull-wand",
+    title: "Skull on a Stick",
+    content:
+      "On New Year's Day I walked through the city with a skull on a stick, calling: beware! beware! The crowd said I was insane. The crowd had not noticed they too had a skull beneath the face.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  {
+    slug: "proverb-ikkyu-brothel-as-temple",
+    title: "Brothel and Temple",
+    content:
+      "I drank in the brothel and meditated in the temple — and the brothel did not lower the meditation, and the meditation did not raise the brothel. Both belong to the dharma; only my embarrassment did not.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  {
+    slug: "proverb-ikkyu-poems-of-rage",
+    title: "Poems of Rage",
+    content:
+      "I have written poems angry at corrupt monks; I have written poems tender to small children; I have written poems on the bellies of women. The dharma was in all three brushstrokes; it does not care about my reputation.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  {
+    slug: "proverb-ikkyu-cloud-water",
+    title: "Cloud-Water Monk",
+    content:
+      "I am a cloud-water monk. The cloud has nowhere to live; the water has nowhere to stay. Whoever calls me his teacher must be willing to walk after the wind.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  {
+    slug: "proverb-ikkyu-bow-to-blossom",
+    title: "Bow to a Cherry Blossom",
+    content:
+      "Bow to a cherry blossom and the blossom does not return the bow; yet some part of the bow is returned, in the body, days later. Practice in this way.",
+    era: "Muromachi",
+    attributedMasterSlug: "ikkyu-sojun",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_arntzen_ikkyu" }],
+  },
+  // ─── Keizan Jōkin ────────────────────────────────────────────────────
+  {
+    slug: "proverb-keizan-broad-seat",
+    title: "Broad Seat",
+    content:
+      "Spread the seat of the practice broadly. Do not gather the dharma into a narrow line of monks; let nuns sit, let the children sit, let the donor sit beside the abbot. The seat that excludes is too small for the buddhas.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-keizan-transmission-record",
+    title: "Record of the Transmission of Light",
+    content:
+      "I write this Record because the lamp must not be left in only one hand. Each face in the lineage held the lamp differently; only by writing them down do we see the family resemblance.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    collection: "Denkōroku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-keizan-women-too",
+    title: "Women Too",
+    content:
+      "If the dharma stops at the gate of the nuns' hall, it is no longer the dharma. I built temples open to women practitioners. Some called me lax. The dharma called me back to my work.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-keizan-three-poisons",
+    title: "Three Poisons in One Cup",
+    content:
+      "Greed, anger, ignorance — three poisons in one cup. To drink them is hell; to refuse them is hell; to look at the cup until the cup itself becomes empty is the practice.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-keizan-ground-of-being",
+    title: "Ground of Being",
+    content:
+      "The ground of being is not below your feet; it is what your feet are pressed into and out of, breath by breath. To practice is to learn how to step on it without forgetting.",
+    era: "Kamakura",
+    attributedMasterSlug: "keizan-jokin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  // ─── Bassui Tokushō ──────────────────────────────────────────────────
+  {
+    slug: "proverb-bassui-who-hears",
+    title: "Who Is the One Who Hears?",
+    content:
+      "Who is hearing this voice? Sit with that question through every cough, every footfall, every bell. The one who hears does not have a name — and yet you have been answering for him all your life.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-bassui-mind-mountain",
+    title: "Mind Without Form",
+    content:
+      "Mind has no form, no color, no weight. Yet it is heavier than the mountain when burdened, lighter than the cloud when free. Find the place where it is neither, and the mountain bows.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-bassui-write-to-laymen",
+    title: "Letter to a Dying Layman",
+    content:
+      "I wrote to a dying layman: do not seek the Buddha outside this body. The body that is dying is the body that has been studying its whole life. Trust it, and the breath that leaves it last carries the answer.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-bassui-mud-and-water",
+    title: "Mud and Water",
+    content:
+      "Mud and water are not enemies; mix them, and the field grows rice. The mind and its troubles are likewise — separated, both starve; together, they feed.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-bassui-do-not-search-outside",
+    title: "Nothing to Find Outside",
+    content:
+      "If you search for Buddha outside, you will find a stranger. If you search inside, you will find no one. Stop searching, and the meeting is unavoidable.",
+    era: "Muromachi",
+    attributedMasterSlug: "bassui-tokusho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Gasan Jitō ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-gasan-jito-river-monk",
+    title: "River Monk",
+    content:
+      "I sit by the river that flows past the temple. The river does not ask whether I am a monk; it does not bow when I bow. Yet whenever I rise, I rise from a longer rest than I started with.",
+    era: "Edo",
+    attributedMasterSlug: "gasan-jito",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-gasan-jito-bow-deep",
+    title: "Bow Deep, Stand Slow",
+    content:
+      "Bow deep, stand slow. The bow is not for me; it is for the body to remember that the floor exists. The slow standing is not for show; it is for the body to remember that the air exists.",
+    era: "Edo",
+    attributedMasterSlug: "gasan-jito",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-gasan-jito-old-pillow",
+    title: "Old Pillow",
+    content:
+      "An old pillow is the best pillow for sleep, and the best pillow for kōan. The shape of the dreamer has worn into it; nothing in it argues back.",
+    era: "Edo",
+    attributedMasterSlug: "gasan-jito",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Gasan Jōseki ────────────────────────────────────────────────────
+  {
+    slug: "proverb-gasan-joseki-five-hindrances",
+    title: "Five Hindrances on the Cushion",
+    content:
+      "Greed, ill-will, sleepiness, restlessness, doubt — five visitors at every sitting. Greet each by name when it arrives; bow when each leaves. After enough visits, they stop ringing the bell.",
+    era: "Kamakura",
+    attributedMasterSlug: "gasan-joseki",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-gasan-joseki-passing-down",
+    title: "Passing Down a Living Lineage",
+    content:
+      "The lineage I pass down is alive only because each receiver is willing to let it kill the part of him that wants to keep it.",
+    era: "Kamakura",
+    attributedMasterSlug: "gasan-joseki",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  {
+    slug: "proverb-gasan-joseki-hidden-temple",
+    title: "Hidden Temple",
+    content:
+      "A temple hidden in the trees teaches you to walk in. A temple at the head of the road teaches you to walk past. The dharma is in either, depending on the kind of legs you arrive on.",
+    era: "Kamakura",
+    attributedMasterSlug: "gasan-joseki",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_bodiford_soto_medieval" }],
+  },
+  // ─── Sengai Gibon ────────────────────────────────────────────────────
+  {
+    slug: "proverb-sengai-circle-triangle-square",
+    title: "Circle, Triangle, Square",
+    content:
+      "I painted a circle, a triangle, and a square. Some called this the universe, the dharma, the Buddha. I called it: ink, ink, and a little more ink. The interpretation is the viewer's body.",
+    era: "Edo",
+    attributedMasterSlug: "sengai-gibon",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-sengai-old-man-laughs",
+    title: "Old Man Laughs",
+    content:
+      "An old man laughs at his own paintings, and the paintings do not mind. So practice — laughed at by the years, the practice does not lose its smile.",
+    era: "Edo",
+    attributedMasterSlug: "sengai-gibon",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-sengai-three-friends",
+    title: "Three Friends",
+    content:
+      "Pine, bamboo, plum — three friends of winter. Each holds firm in a different way: the pine by not letting go, the bamboo by bending, the plum by blooming. Choose your way of holding.",
+    era: "Edo",
+    attributedMasterSlug: "sengai-gibon",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-sengai-do-not-leave-painting",
+    title: "Do Not Leave the Painting",
+    content:
+      "Do not finish a painting and leave it behind. Carry it in your eye. The next painting begins where the last one's ink dries.",
+    era: "Edo",
+    attributedMasterSlug: "sengai-gibon",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Tōyō Eichō (and other early Japanese Rinzai) ───────────────────
+  {
+    slug: "proverb-toyo-eicho-zenrin",
+    title: "Compiling the Zen Forest",
+    content:
+      "I gathered capping phrases as a forester gathers cuttings — not because the trees needed gathering, but so that students who could not climb would still hear the wind in the branches.",
+    era: "Muromachi",
+    attributedMasterSlug: "toyo-eicho",
+    collection: "Zenrin Kushū",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_hori_zen_sand" }],
+  },
+  {
+    slug: "proverb-toyo-eicho-only-tree",
+    title: "Only the Tree Knows",
+    content:
+      "A capping phrase is a leaf detached from the tree. To know what the leaf says, return it to the tree of your own practice. Only the tree knows where each leaf belongs.",
+    era: "Muromachi",
+    attributedMasterSlug: "toyo-eicho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_hori_zen_sand" }],
+  },
+  {
+    slug: "proverb-toyo-eicho-anthology-uses",
+    title: "Use the Anthology Sparingly",
+    content:
+      "Do not memorize the whole anthology and quote it at others; that is parrot work. Carry one phrase in the body for a month, and you have done more than reciting a hundred.",
+    era: "Muromachi",
+    attributedMasterSlug: "toyo-eicho",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_hori_zen_sand" }],
+  },
+  // ─── Tettō Gikō ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-tetto-giko-flag-on-mountain",
+    title: "Flag on the Mountain",
+    content:
+      "Plant the lineage flag on the mountain. The wind will tear it; rebuild it. The students who stay are the ones who can patch a flag in a storm.",
+    era: "Kamakura",
+    attributedMasterSlug: "tetto-giko",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-tetto-giko-small-temple",
+    title: "Small Temple",
+    content:
+      "Better a small temple where the floor is swept than a large one where the doctrine is admired. A swept floor is itself a doctrine.",
+    era: "Kamakura",
+    attributedMasterSlug: "tetto-giko",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-tetto-giko-night-bell",
+    title: "Night Bell",
+    content:
+      "The night bell rings for those who are still awake. The dharma rings for those who are willing to be woken. Both rings are a single sound.",
+    era: "Kamakura",
+    attributedMasterSlug: "tetto-giko",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Yamamoto Gempō ──────────────────────────────────────────────────
+  {
+    slug: "proverb-yamamoto-gempo-blind-eyes",
+    title: "Blind Eyes See",
+    content:
+      "I went blind young, and the world arrived through other senses. The dharma was not less for it — perhaps more, since I could no longer be distracted by the appearance of the dharma.",
+    era: "Modern",
+    attributedMasterSlug: "yamamoto-gempo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-yamamoto-gempo-bow-to-criminal",
+    title: "Bow to the Condemned",
+    content:
+      "When asked to certify the death-sentence document, I refused. I bow to a man who is about to die; I do not certify his end. The bow was the dharma; the certificate would have been the law.",
+    era: "Modern",
+    attributedMasterSlug: "yamamoto-gempo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-yamamoto-gempo-rinzai-survival",
+    title: "Survival of Rinzai",
+    content:
+      "After the war, when temples were reduced to ashes, the dharma was reduced to its essentials. We rebuilt smaller buildings around the same emptiness, and the practice was unbroken.",
+    era: "Modern",
+    attributedMasterSlug: "yamamoto-gempo",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  // ─── Nampo Gentaku / Shinchi Kakushin (early Rinzai) ─────────────────
+  {
+    slug: "proverb-nampo-gentaku-old-temple",
+    title: "Old Temple, New Bell",
+    content:
+      "An old temple sometimes needs a new bell. The bronze remembers the casting; the air remembers the ringing. The students hear only the ringing — and that is enough.",
+    era: "Kamakura",
+    attributedMasterSlug: "nampo-gentaku",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-shinchi-kakushin-flute-and-zen",
+    title: "Flute and Zen",
+    content:
+      "I brought the shakuhachi back from China alongside the dharma. The flute and the koan are not different practices — both ask you to stop talking long enough to hear the next note.",
+    era: "Kamakura",
+    attributedMasterSlug: "shinchi-kakushin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+  {
+    slug: "proverb-shinchi-kakushin-fuke",
+    title: "Fuke Zen Origins",
+    content:
+      "I traced the line of Fuke back to a wandering Tang monk who rang a small bell through the marketplace. The bell was the only sutra he carried; everyone who heard it was instructed.",
+    era: "Kamakura",
+    attributedMasterSlug: "shinchi-kakushin",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_dumoulin_japan_vol2" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-korean.ts
+++ b/scripts/data/proverbs/expansion-korean.ts
@@ -1,0 +1,392 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const KOREAN_PROVERBS: CuratedProverb[] = [
+  // ─── Jinul (Bojo) ────────────────────────────────────────────────────
+  {
+    slug: "proverb-jinul-three-treatises",
+    title: "The Three Mysterious Gates",
+    content:
+      "The first gate is the word; the second gate is the meaning; the third gate is the body and life. The student who passes the first stops at the word; the second stops at the meaning. Only the third sets down both word and meaning together.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    collection: "Excerpts on the True Mind (Chinsim Chiksŏl)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 159–213" }],
+  },
+  {
+    slug: "proverb-jinul-ox-on-mountain",
+    title: "An Ox on the Mountain",
+    content:
+      "Practitioners are like an ox on the mountain: from a distance the ox seems to walk along the path of clouds, yet at every moment its hooves are on the dirt. Awakening does not lift you off the ground — it sets you firmly on it.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 17–97" }],
+  },
+  {
+    slug: "proverb-jinul-no-doctrine-outside",
+    title: "No Doctrine Outside the Mind",
+    content:
+      "If you take the scriptures as the highest, the mind is buried under words. If you take the mind as the highest and abandon the scriptures, you cut yourself off from the past masters. Practice with both, and neither becomes a cage.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    collection: "Susimgyeol",
+    licenseStatus: "cc_by",
+    citations: [
+      { sourceId: "src_buswell_radiance", pageOrSection: "pp. 140–157" },
+      { sourceId: "src_park_korean_seon" },
+    ],
+  },
+  {
+    slug: "proverb-jinul-householder-mountain",
+    title: "Householder and Mountain Monk",
+    content:
+      "The mountain monk who congratulates himself on having left the world has not yet left himself. The householder who is empty in the marketplace is already in the mountains.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  {
+    slug: "proverb-jinul-do-not-grasp",
+    title: "Do Not Grasp Your Own Awakening",
+    content:
+      "When awakening comes, do not grasp it. When it goes, do not chase it. Both grasping and chasing arise from the same restless habit. Sit until even the joy of seeing becomes another thing to release.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 213–256" }],
+  },
+  {
+    slug: "proverb-jinul-samadhi-prajna",
+    title: "Samādhi and Prajñā in One Practice",
+    content:
+      "Samādhi without prajñā becomes dullness; prajñā without samādhi becomes scattering. Hold them as two wings of one bird, and the bird neither falls into stupor nor blows away in the wind.",
+    era: "Goryeo",
+    attributedMasterSlug: "jinul",
+    collection: "Secrets on Cultivating the Mind",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 140–158" }],
+  },
+  // ─── Chingak Hyesim ──────────────────────────────────────────────────
+  {
+    slug: "proverb-hyesim-no-ground-to-stand",
+    title: "No Ground to Stand On",
+    content:
+      "The hwadu pulls the ground from under your feet. If at that moment you reach for a wall, you have already missed it. Fall straight through, and you will find your old life waiting for you, only without the one who used to live it.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [
+      { sourceId: "src_buswell_radiance", pageOrSection: "pp. 98–130" },
+      { sourceId: "src_buswell_monastic", pageOrSection: "pp. 149–190" },
+    ],
+  },
+  {
+    slug: "proverb-hyesim-poetry-and-doubt",
+    title: "Poetry and the Great Doubt",
+    content:
+      "I have written verses for thirty years and never once captured the moon. The student who works with the hwadu day and night, and gives up the hope of capturing it, will one day notice that the moon has been writing the verses through him.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 98–130" }],
+  },
+  {
+    slug: "proverb-hyesim-broken-monk",
+    title: "The Broken Monk",
+    content:
+      "A monk who has been broken by his practice — broken in pride, broken in plans — is finally fit to teach. A monk still whole is still hiding.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 149–190" }],
+  },
+  {
+    slug: "proverb-hyesim-three-questions",
+    title: "Three Questions, One Throat",
+    content:
+      "Who is hearing this voice? Who is asking who hears? Who is the one who asks who asks? When the three questions arise from one throat and go nowhere, the throat itself opens.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 98–130" }],
+  },
+  {
+    slug: "proverb-hyesim-not-a-thing",
+    title: "Not a Thing to Hand Over",
+    content:
+      "If I had something to hand you, you would not need me. Because I have nothing to hand over, I will sit with you until you discover what you already have.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 98–130" }],
+  },
+  {
+    slug: "proverb-hyesim-hwadu-not-an-answer",
+    title: "The Hwadu Is Not an Answer",
+    content:
+      "The hwadu is not an answer waiting to be found. It is a wedge driven into the seam of your habits. When the wedge is fully in, the habits split — not the hwadu.",
+    era: "Goryeo",
+    attributedMasterSlug: "chingak-hyesim",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 149–190" }],
+  },
+  // ─── Taego Bou ───────────────────────────────────────────────────────
+  {
+    slug: "proverb-taego-five-houses-one-river",
+    title: "Five Houses, One River",
+    content:
+      "The five houses of Chan are five fords on one river. Cross at any of them and you reach the same farther shore. Argue about which ford is best, and you stand on this side until you die.",
+    era: "Goryeo",
+    attributedMasterSlug: "taego-bou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 17–97" }],
+  },
+  {
+    slug: "proverb-taego-pure-rule",
+    title: "The Pure Rule for One Person",
+    content:
+      "The Pure Rule of the assembly was written for many; the pure rule for one person is written every morning before the bell. Fold the robe straight, sweep the cloister, sit.",
+    era: "Goryeo",
+    attributedMasterSlug: "taego-bou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  {
+    slug: "proverb-taego-king-and-monk",
+    title: "King and Monk",
+    content:
+      "The king came to ask about the dharma. I said: take off the crown for an hour, and your question will answer itself. He laughed; I laughed. The hour passed, and we both stood up changed.",
+    era: "Goryeo",
+    attributedMasterSlug: "taego-bou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 17–97" }],
+  },
+  {
+    slug: "proverb-taego-no-back-no-front",
+    title: "No Back, No Front",
+    content:
+      "When you face the cushion, the cushion is in front. When you face the marketplace, the marketplace is in front. The seat that has no back and no front is the one you carry between them.",
+    era: "Goryeo",
+    attributedMasterSlug: "taego-bou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  {
+    slug: "proverb-taego-mountain-of-gold",
+    title: "Mountain of Gold, Mountain of Mist",
+    content:
+      "If a mountain of gold stood at the door, students would line up to climb it. A mountain of mist costs nothing, contains nothing, and only the sincere try to enter it.",
+    era: "Goryeo",
+    attributedMasterSlug: "taego-bou",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_radiance", pageOrSection: "pp. 17–97" }],
+  },
+  // ─── Seosan Hyujeong ─────────────────────────────────────────────────
+  {
+    slug: "proverb-seosan-three-bodies-one-sword",
+    title: "Three Bodies, One Sword",
+    content:
+      "Doctrine is the dharma body, meditation is the reward body, conduct is the manifestation body. The Sŏn student wields all three with one sword — and the sword cuts only delusion, never the dharma.",
+    era: "Joseon",
+    attributedMasterSlug: "seosan-hyujeong",
+    collection: "Mirror of Seon (Seongamnok)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58" }],
+  },
+  {
+    slug: "proverb-seosan-warrior-monk",
+    title: "Warrior-Monk",
+    content:
+      "A monk who takes up the bow does not become a soldier; he becomes a monk in armour. The arrow loosed from the dharma is the first one; the second is the body that loosed it. Both must return to the bow.",
+    era: "Joseon",
+    attributedMasterSlug: "seosan-hyujeong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  {
+    slug: "proverb-seosan-three-religions-one-mind",
+    title: "Three Religions, One Mind",
+    content:
+      "Confucius works on the village; Laozi works on the body; the Buddha works on the mind. Where the three meet, no priest is needed — the work is already done.",
+    era: "Joseon",
+    attributedMasterSlug: "seosan-hyujeong",
+    collection: "Mirror of the Three Teachings (Samga Kwigam)",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58" }],
+  },
+  {
+    slug: "proverb-seosan-empty-temple",
+    title: "An Empty Temple",
+    content:
+      "An empty temple is not a failed temple. The bell still rings on the empty hour, and the monks on the road carry the temple inside their robes.",
+    era: "Joseon",
+    attributedMasterSlug: "seosan-hyujeong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58" }],
+  },
+  {
+    slug: "proverb-seosan-mosquito-iron-ox-second",
+    title: "After the Mosquito Has Bored In",
+    content:
+      "After the mosquito has bored into the iron ox, the question becomes: where is the mosquito now? Find that mosquito, and the iron ox stands up and walks.",
+    era: "Joseon",
+    attributedMasterSlug: "seosan-hyujeong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58" }],
+  },
+  // ─── Gyeongheo Seongu ────────────────────────────────────────────────
+  {
+    slug: "proverb-gyeongheo-no-need-to-leave",
+    title: "No Need to Leave the World",
+    content:
+      "When the world is on fire, monks discuss whether to leave it. While they discuss, the world goes on burning. Sit down where you are; the fire becomes light, and the light shows the road.",
+    era: "Joseon",
+    attributedMasterSlug: "gyeongheo-seongu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-gyeongheo-revival",
+    title: "Reviving What Never Died",
+    content:
+      "Some say I revived the Korean Sŏn. The Sŏn was never dead; only the people sleeping in front of it were. To revive them was simpler than they thought, and harder than I thought.",
+    era: "Joseon",
+    attributedMasterSlug: "gyeongheo-seongu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  {
+    slug: "proverb-gyeongheo-cholera-mountain",
+    title: "Cholera and the Mountain",
+    content:
+      "When the cholera came, I went into the village instead of the mountain. The mountain has been there a thousand years; it can wait. The dying cannot.",
+    era: "Joseon",
+    attributedMasterSlug: "gyeongheo-seongu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-gyeongheo-no-difference",
+    title: "No Difference Between High and Low",
+    content:
+      "I have eaten at the table of the king and at the table of the leper. The mouth that opened was the same mouth, and what entered it became the same body of the Way.",
+    era: "Joseon",
+    attributedMasterSlug: "gyeongheo-seongu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-gyeongheo-sermon-of-the-meadow",
+    title: "Sermon of the Meadow",
+    content:
+      "The meadow has not asked any of these wildflowers to bloom. The wildflowers have not asked the meadow to hold them. So a teacher and a student are when nothing is asked.",
+    era: "Joseon",
+    attributedMasterSlug: "gyeongheo-seongu",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_park_korean_seon" }],
+  },
+  // ─── Seongcheol ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-seongcheol-mountain-do-not-leave",
+    title: "Do Not Leave the Mountain",
+    content:
+      "I did not leave Haeinsa for ten years. Some called this attachment. Whoever cannot sit through one full season on one cushion will not understand what was being held.",
+    era: "Modern",
+    attributedMasterSlug: "seongcheol",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-seongcheol-bow-three-thousand",
+    title: "Three Thousand Bows",
+    content:
+      "If you wish to study with me, do three thousand bows first. Not as a test of devotion, but so the body learns to lower itself before the mind has its say.",
+    era: "Modern",
+    attributedMasterSlug: "seongcheol",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-seongcheol-mountain-wave",
+    title: "The Mountain Is the Wave",
+    content:
+      "The Diamond Sūtra says all conditioned things are like dreams, like dew. I add: the mountain is also a slow wave. Sit with the wave at its slowest, and the speed of your own life appears.",
+    era: "Modern",
+    attributedMasterSlug: "seongcheol",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-seongcheol-not-celebrity",
+    title: "Not a Celebrity",
+    content:
+      "When laypeople come to make me into a celebrity, I send them home. A monk who collects admirers has lost the only audience that mattered: the morning bell, ringing whether anyone listens or not.",
+    era: "Modern",
+    attributedMasterSlug: "seongcheol",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  {
+    slug: "proverb-seongcheol-radical-position",
+    title: "Sudden Awakening, Sudden Cultivation",
+    content:
+      "Some teachers say sudden awakening, gradual cultivation. I say if the awakening is genuine, the cultivation has already happened — the work that remains is only to stop pretending it has not.",
+    era: "Modern",
+    attributedMasterSlug: "seongcheol",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_buswell_monastic", pageOrSection: "pp. 191–229" }],
+  },
+  // ─── Seung Sahn ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-seung-sahn-just-do-it",
+    title: "Just Do It",
+    content:
+      "When you eat, just eat. When you sit, just sit. When you read this, just read it. Do not save anything for later — there is no later.",
+    era: "Modern",
+    attributedMasterSlug: "seung-sahn",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_seungsahn_compass_zen" }],
+  },
+  {
+    slug: "proverb-seung-sahn-bodhisattva-vow",
+    title: "Vow Before Wisdom",
+    content:
+      "First the great vow, then the great doubt, then the great courage. Wisdom is the smallest of these; without the vow, wisdom is only cleverness.",
+    era: "Modern",
+    attributedMasterSlug: "seung-sahn",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_seungsahn_compass_zen" }],
+  },
+  {
+    slug: "proverb-seung-sahn-keep-mouth-shut",
+    title: "Open Mouth, Already a Mistake",
+    content:
+      "Open your mouth, already a mistake. So why do I speak? Because the mistake is sometimes the medicine.",
+    era: "Modern",
+    attributedMasterSlug: "seung-sahn",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_seungsahn_compass_zen" }],
+  },
+  {
+    slug: "proverb-seung-sahn-students-three",
+    title: "Three Kinds of Students",
+    content:
+      "First-class student: hears one word, gets it, goes to work. Second-class student: hears one word, asks ten more, gets it, goes to work. Third-class student: hears ten words, takes notes, never goes to work. Be the first kind, even on the days you are the third.",
+    era: "Modern",
+    attributedMasterSlug: "seung-sahn",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_seungsahn_compass_zen" }],
+  },
+  {
+    slug: "proverb-seung-sahn-throw-it-away",
+    title: "Throw It All Away",
+    content:
+      "Whatever you have, throw it away. Then whatever throws it away, throw that away too. When there is nothing left to throw, you have arrived where you always were.",
+    era: "Modern",
+    attributedMasterSlug: "seung-sahn",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_seungsahn_compass_zen" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-modern.ts
+++ b/scripts/data/proverbs/expansion-modern.ts
@@ -1,0 +1,444 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const MODERN_PROVERBS: CuratedProverb[] = [
+  // ─── Shunryu Suzuki ──────────────────────────────────────────────────
+  {
+    slug: "proverb-shunryu-suzuki-beginners-mind",
+    title: "Beginner's Mind",
+    content:
+      "In the beginner's mind there are many possibilities; in the expert's mind there are few. Bring the beginner with you to the cushion every morning, and the morning is wide.",
+    era: "Modern",
+    attributedMasterSlug: "shunryu-suzuki",
+    collection: "Zen Mind, Beginner's Mind",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  {
+    slug: "proverb-shunryu-suzuki-each-of-you-is-perfect",
+    title: "Perfect, and Could Use a Little Improvement",
+    content:
+      "Each of you is perfect the way you are — and you can use a little improvement. Both are true at once; neither cancels the other.",
+    era: "Modern",
+    attributedMasterSlug: "shunryu-suzuki",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  {
+    slug: "proverb-shunryu-suzuki-not-deeper",
+    title: "Not Deeper, Just Here",
+    content:
+      "If your sitting feels shallow today, do not look for deeper sitting. Look for being here. The deepening will follow you in without an invitation.",
+    era: "Modern",
+    attributedMasterSlug: "shunryu-suzuki",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  // ─── Taisen Deshimaru ────────────────────────────────────────────────
+  {
+    slug: "proverb-deshimaru-mushotoku",
+    title: "Mushotoku — Without Goal",
+    content:
+      "Sit without goal — mushotoku. The student who sits to attain has already left the cushion. Drop the goal, and the cushion attains the student.",
+    era: "Modern",
+    attributedMasterSlug: "taisen-deshimaru",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  {
+    slug: "proverb-deshimaru-here-and-now",
+    title: "Here and Now",
+    content:
+      "The dojo is here, the cushion is here, the breath is here. There is no Japan, no robe, no master that is not also here. Practice in the place you are.",
+    era: "Modern",
+    attributedMasterSlug: "taisen-deshimaru",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  {
+    slug: "proverb-deshimaru-back-straight",
+    title: "Back Straight, Mind Loose",
+    content:
+      "Stretch the spine; loosen the mind. The spine is the discipline of the body; the loose mind is the discipline of the discipline. Both belong to the same Zen.",
+    era: "Modern",
+    attributedMasterSlug: "taisen-deshimaru",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  {
+    slug: "proverb-deshimaru-bushido",
+    title: "Way of the Warrior, Way of Zen",
+    content:
+      "The way of the warrior and the way of Zen meet on the same cushion. Both ask you to drop the fear of dying. The warrior drops it for one battle; the Zen student drops it for every breath.",
+    era: "Modern",
+    attributedMasterSlug: "taisen-deshimaru",
+    collection: "The Zen Way to the Martial Arts",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  // ─── Taizan Maezumi ──────────────────────────────────────────────────
+  {
+    slug: "proverb-maezumi-appreciate-your-life",
+    title: "Appreciate Your Life",
+    content:
+      "Appreciate your life — this very life, with its fatigue, its mistakes, its small kindnesses. The Buddha did not promise a different life; only this one fully met.",
+    era: "Modern",
+    attributedMasterSlug: "taizan-maezumi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-maezumi-three-pillars",
+    title: "Three Pillars of Practice",
+    content:
+      "Sitting, study, and work — three pillars of one practice. Drop one and the roof leans; drop two and it falls; carry all three and the temple is strong even in storms.",
+    era: "Modern",
+    attributedMasterSlug: "taizan-maezumi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-maezumi-one-master-no-master",
+    title: "One Master, No Master",
+    content:
+      "Take one master in this life and listen to him fully — and after listening, take no master at all. Without the first, the second is laziness; without the second, the first is idolatry.",
+    era: "Modern",
+    attributedMasterSlug: "taizan-maezumi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-maezumi-be-yourself",
+    title: "Be Yourself",
+    content:
+      "Be yourself, completely yourself. The Buddha had no other plan for you. The trying-to-be-someone-else is the only thing he ever asked us to give up.",
+    era: "Modern",
+    attributedMasterSlug: "taizan-maezumi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-maezumi-imperfect-teacher",
+    title: "Imperfect Teacher",
+    content:
+      "I am an imperfect teacher; I have stumbled in plain sight. Do not study my stumble — study the way I rose. The dharma is in the rising, even when the stumble was clearly mine.",
+    era: "Modern",
+    attributedMasterSlug: "taizan-maezumi",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  // ─── John Daido Loori ────────────────────────────────────────────────
+  {
+    slug: "proverb-loori-eight-gates",
+    title: "The Eight Gates",
+    content:
+      "Zazen, study, liturgy, art practice, body practice, work practice, the precepts, and right action — eight gates leading to one yard. Walk through each at your own pace.",
+    era: "Modern",
+    attributedMasterSlug: "john-daido-loori",
+    collection: "The Eight Gates of Zen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-loori-mountain-monastery",
+    title: "Mountain and Monastery",
+    content:
+      "The mountain has been at this practice longer than any teacher in the building. When the bell rings, listen for the way the mountain sits beneath it.",
+    era: "Modern",
+    attributedMasterSlug: "john-daido-loori",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-loori-camera-lens",
+    title: "Camera as Cushion",
+    content:
+      "Photographing the river, I sat with the river for hours. The shutter clicked once. The picture was good; the morning was the practice.",
+    era: "Modern",
+    attributedMasterSlug: "john-daido-loori",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-loori-koan-and-creativity",
+    title: "Koan and Creativity",
+    content:
+      "Painting, calligraphy, theater — each can be a koan if you let the work cut you. The cut is not destruction; it is the doorway through which you stop being separate from the work.",
+    era: "Modern",
+    attributedMasterSlug: "john-daido-loori",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  // ─── Charlotte Joko Beck ─────────────────────────────────────────────
+  {
+    slug: "proverb-beck-everyday-zen",
+    title: "Everyday Zen",
+    content:
+      "There is no special place for practice. The kitchen, the office, the traffic jam — these are the meditation hall. The cushion is only for rehearsal.",
+    era: "Modern",
+    attributedMasterSlug: "charlotte-joko-beck",
+    collection: "Everyday Zen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_beck_everyday_zen" }],
+  },
+  {
+    slug: "proverb-beck-stop-fixing",
+    title: "Stop Fixing Yourself",
+    content:
+      "Practice is not the work of fixing yourself. It is the work of seeing what is, including the wish to fix. Once the wish is seen clearly, the fixing-energy returns to the body as ordinary attention.",
+    era: "Modern",
+    attributedMasterSlug: "charlotte-joko-beck",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_beck_everyday_zen" }],
+  },
+  {
+    slug: "proverb-beck-no-magic",
+    title: "No Magic",
+    content:
+      "There is no magic in this practice. There is only the willingness to feel what you are already feeling, and not run. After many years, the not-running becomes ordinary.",
+    era: "Modern",
+    attributedMasterSlug: "charlotte-joko-beck",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_beck_everyday_zen" }],
+  },
+  {
+    slug: "proverb-beck-relationships",
+    title: "Relationships as Practice",
+    content:
+      "Your most difficult relationship is your most reliable teacher. The cushion has been preparing you for it; the temple has only been a rehearsal.",
+    era: "Modern",
+    attributedMasterSlug: "charlotte-joko-beck",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_beck_everyday_zen" }],
+  },
+  // ─── Bernie Glassman ─────────────────────────────────────────────────
+  {
+    slug: "proverb-glassman-bearing-witness",
+    title: "Bearing Witness",
+    content:
+      "First, do not know. Second, bear witness. Third, take action. The order is not optional; if action comes first, you become only another opinion in the world.",
+    era: "Modern",
+    attributedMasterSlug: "bernie-tetsugen-glassman",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_glassman_bearing_witness" }],
+  },
+  {
+    slug: "proverb-glassman-street-retreat",
+    title: "Street Retreat",
+    content:
+      "We sat on the streets of the city without money, without robes. People passed us; nobody bowed. The dharma was on the sidewalk all the same.",
+    era: "Modern",
+    attributedMasterSlug: "bernie-tetsugen-glassman",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_glassman_bearing_witness" }],
+  },
+  {
+    slug: "proverb-glassman-not-knowing-as-vow",
+    title: "Not-Knowing as a Vow",
+    content:
+      "Not-knowing is not ignorance. It is a vow not to fix the situation in advance with the answers you brought from yesterday.",
+    era: "Modern",
+    attributedMasterSlug: "bernie-tetsugen-glassman",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_glassman_bearing_witness" }],
+  },
+  // ─── Dainin Katagiri ─────────────────────────────────────────────────
+  {
+    slug: "proverb-katagiri-returning-silence",
+    title: "Returning to Silence",
+    content:
+      "Silence is not the absence of sound; it is the place from which sounds arise. Return to it through the day, and the day stops being a chain of noises.",
+    era: "Modern",
+    attributedMasterSlug: "dainin-katagiri",
+    collection: "Returning to Silence",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_katagiri_returning_silence" }],
+  },
+  {
+    slug: "proverb-katagiri-each-moment",
+    title: "Each Moment Is the Universe",
+    content:
+      "Each moment is the entire universe. There is nothing outside this breath; nothing outside this footstep. To search for more is to stand on the universe and ask where it has gone.",
+    era: "Modern",
+    attributedMasterSlug: "dainin-katagiri",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_katagiri_returning_silence" }],
+  },
+  {
+    slug: "proverb-katagiri-you-have-to-say-something",
+    title: "You Have to Say Something",
+    content:
+      "Sooner or later, you have to say something. Silence is the start of practice; speech is its responsibility. Choose what to say after long sitting; it will be the right thing.",
+    era: "Modern",
+    attributedMasterSlug: "dainin-katagiri",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_katagiri_returning_silence" }],
+  },
+  {
+    slug: "proverb-katagiri-spirit-of-practice",
+    title: "Spirit of Practice",
+    content:
+      "Practice with the spirit of an apprentice and the patience of a craftsman. The apprentice can ask any question; the craftsman keeps working through the unanswered ones.",
+    era: "Modern",
+    attributedMasterSlug: "dainin-katagiri",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_katagiri_returning_silence" }],
+  },
+  // ─── Robert Aitken ───────────────────────────────────────────────────
+  {
+    slug: "proverb-aitken-clover",
+    title: "Mind of Clover",
+    content:
+      "The bodhisattva's mind is the mind of clover — small leaves, intricate, modest, useful, growing in places no one chose. Be useful in the unchosen places.",
+    era: "Modern",
+    attributedMasterSlug: "robert-aitken",
+    collection: "The Mind of Clover",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_aitken_mind_clover" }],
+  },
+  {
+    slug: "proverb-aitken-precepts",
+    title: "Precepts as Practice",
+    content:
+      "The precepts are not laws to obey but practices to undertake. Each one is a koan in the body — solved by the way you live, not by the way you think about it.",
+    era: "Modern",
+    attributedMasterSlug: "robert-aitken",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_aitken_mind_clover" }],
+  },
+  {
+    slug: "proverb-aitken-engaged-citizen",
+    title: "Engaged Citizen",
+    content:
+      "A Zen student is also a citizen. Sit in the morning; vote in the afternoon; protest in the evening if needed. The cushion does not absolve us from the polis.",
+    era: "Modern",
+    attributedMasterSlug: "robert-aitken",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_aitken_mind_clover" }],
+  },
+  // ─── Jiyu-Kennett ────────────────────────────────────────────────────
+  {
+    slug: "proverb-kennett-zen-eternal-life",
+    title: "Zen Is Eternal Life",
+    content:
+      "There is no death in this practice — only the falling away of forms. The form falls; the practice continues in another form. Whoever has truly sat knows there has never been a death.",
+    era: "Modern",
+    attributedMasterSlug: "jiyu-kennett",
+    collection: "Zen Is Eternal Life",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kennett_zen_eternal" }],
+  },
+  {
+    slug: "proverb-kennett-monastery-rule",
+    title: "Monastery Rule for One",
+    content:
+      "If you cannot live by the monastery rule, write a monastery rule for one — and live by it as if a hundred others were watching. They are not, but the dharma is.",
+    era: "Modern",
+    attributedMasterSlug: "jiyu-kennett",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kennett_zen_eternal" }],
+  },
+  {
+    slug: "proverb-kennett-female-master",
+    title: "Female Master",
+    content:
+      "I was the first Western woman to be transmitted in our line. They said I would not last. The dharma did not consult them, and I am still here.",
+    era: "Modern",
+    attributedMasterSlug: "jiyu-kennett",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_kennett_zen_eternal" }],
+  },
+  // ─── Kobun Chino Otogawa ─────────────────────────────────────────────
+  {
+    slug: "proverb-kobun-archery",
+    title: "Archery Without Arrow",
+    content:
+      "Draw the bow without an arrow. The bow is heaviest then. After many drawings, the bow becomes part of the arm; only then is the arrow placed.",
+    era: "Modern",
+    attributedMasterSlug: "kobun-chino-otogawa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  {
+    slug: "proverb-kobun-zazen-as-poetry",
+    title: "Zazen as Poetry",
+    content:
+      "Zazen is the body's poetry. It is written without ink, read without eyes, and yet a careful student can recognize the lines years later in the way the body sits.",
+    era: "Modern",
+    attributedMasterSlug: "kobun-chino-otogawa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  {
+    slug: "proverb-kobun-do-not-imitate",
+    title: "Do Not Imitate Your Teacher",
+    content:
+      "Do not imitate your teacher's posture, voice, or favorite cup. Imitate his willingness to sit. The rest will fit your body in its own way.",
+    era: "Modern",
+    attributedMasterSlug: "kobun-chino-otogawa",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_chadwick_crooked_cucumber" }],
+  },
+  // ─── Philippe Reiryu Coupey & Olivier Reigen Wang-Genh ───────────────
+  {
+    slug: "proverb-coupey-european-zen",
+    title: "Zen Without Country",
+    content:
+      "Zen has no country. It puts on the language of the people in front of it. We sit in French, in Italian, in Polish — and the dharma sits in all of them, and asks for none.",
+    era: "Modern",
+    attributedMasterSlug: "philippe-reiryu-coupey",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  {
+    slug: "proverb-coupey-questions-without-answer",
+    title: "Living the Questions",
+    content:
+      "Live the questions for which there is no answer. The right answer would only end the question; living it brings the question itself into the breath.",
+    era: "Modern",
+    attributedMasterSlug: "philippe-reiryu-coupey",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  {
+    slug: "proverb-wang-genh-strasbourg",
+    title: "Sitting in Strasbourg",
+    content:
+      "On winter mornings the dojo in Strasbourg is colder than the streets. We sit in coats; we sit anyway. The cold is part of the morning; the morning is part of the practice.",
+    era: "Modern",
+    attributedMasterSlug: "olivier-reigen-wang-genh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_deshimaru_zen_way_to_martial_arts" }],
+  },
+  // ─── Susan Myoyu Andersen ────────────────────────────────────────────
+  {
+    slug: "proverb-andersen-care-and-precepts",
+    title: "Care and Precepts",
+    content:
+      "The precepts are not a set of laws but a practice of care. To take a precept is to take responsibility for a kind of attention; to break a precept is to take responsibility for the breaking.",
+    era: "Modern",
+    attributedMasterSlug: "susan-myoyu-andersen",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  // ─── Jan Chozen Bays ─────────────────────────────────────────────────
+  {
+    slug: "proverb-jan-chozen-bays-mindful-eating",
+    title: "Mindful Eating",
+    content:
+      "Sit with one raisin. Look at it; smell it; chew it slowly. After one raisin, the rest of the meal becomes a teacher. After many meals, the day becomes the cushion.",
+    era: "Modern",
+    attributedMasterSlug: "jan-chozen-bays",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+  {
+    slug: "proverb-jan-chozen-bays-pediatrician",
+    title: "Pediatrician's Practice",
+    content:
+      "I have practiced as a pediatrician and as a Zen teacher. The two practices wash the hands of the same person; the children have not noticed any difference.",
+    era: "Modern",
+    attributedMasterSlug: "jan-chozen-bays",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_loori_eight_gates" }],
+  },
+];

--- a/scripts/data/proverbs/expansion-sources.ts
+++ b/scripts/data/proverbs/expansion-sources.ts
@@ -1,0 +1,263 @@
+/**
+ * Sources used to anchor the proverb-expansion batch (issue #15).
+ *
+ * License posture: every English rendering of the proverbs is editorial
+ * (cc_by, written for this project). The sources below are scholarly
+ * anchors for attribution, period, and substantive claim — not quoted at
+ * length. A handful of entries quote pre-1929 public-domain translations
+ * directly; those entries flag `licenseStatus: "public_domain"` and cite
+ * the PD edition.
+ */
+
+import type { CuratedProverbSource } from "../curated-proverbs";
+
+export const EXPANSION_SOURCES: CuratedProverbSource[] = [
+  // ─── Indian / early Buddhist ─────────────────────────────────────────
+  {
+    id: "src_dhammapada_muller_1881",
+    type: "text_edition",
+    title: "The Dhammapada (Sacred Books of the East, Vol. X)",
+    author: "Max Müller (trans.)",
+    publicationDate: "1881",
+    reliability: "scholarly",
+    url: "https://www.sacred-texts.com/bud/sbe10/index.htm",
+  },
+  {
+    id: "src_rhys_davids_buddhist_suttas_1881",
+    type: "text_edition",
+    title: "Buddhist Suttas (Sacred Books of the East, Vol. XI)",
+    author: "T. W. Rhys Davids (trans.)",
+    publicationDate: "1881",
+    reliability: "scholarly",
+    url: "https://www.sacred-texts.com/bud/sbe11/index.htm",
+  },
+  {
+    id: "src_dt_suzuki_essays_1927",
+    type: "monograph",
+    title: "Essays in Zen Buddhism, First Series",
+    author: "D. T. Suzuki",
+    publicationDate: "1927",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_okakura_book_of_tea_1906",
+    type: "monograph",
+    title: "The Book of Tea",
+    author: "Kakuzō Okakura",
+    publicationDate: "1906",
+    reliability: "secondary",
+  },
+  // ─── Tang/Song Chan scholarship ──────────────────────────────────────
+  {
+    id: "src_app_yunmen",
+    type: "monograph",
+    title: "Master Yunmen: From the Record of the Chan Master 'Gate of the Clouds'",
+    author: "Urs App (trans.)",
+    publicationDate: "1994",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_poceski_ordinary_mind",
+    type: "monograph",
+    title: "Ordinary Mind as the Way: The Hongzhou School and the Growth of Chan Buddhism",
+    author: "Mario Poceski",
+    publicationDate: "2007",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_welter_linji",
+    type: "monograph",
+    title: "The Linji Lu and the Creation of Chan Orthodoxy",
+    author: "Albert Welter",
+    publicationDate: "2008",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_schlutter_dahui",
+    type: "monograph",
+    title: "How Zen Became Zen: The Dispute Over Enlightenment and the Formation of Chan Buddhism in Song-Dynasty China",
+    author: "Morten Schlütter",
+    publicationDate: "2008",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_mcrae_seeing_through_zen",
+    type: "monograph",
+    title: "Seeing Through Zen: Encounter, Transformation, and Genealogy in Chinese Chan Buddhism",
+    author: "John R. McRae",
+    publicationDate: "2003",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_foulk_caodong",
+    type: "edited_chapter",
+    title: "Form and Function of Koan Literature: A Historical Overview (in The Kōan, eds. Heine & Wright)",
+    author: "T. Griffith Foulk",
+    publicationDate: "2000",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_leighton_cultivating_empty_field",
+    type: "text_edition",
+    title: "Cultivating the Empty Field: The Silent Illumination of Zen Master Hongzhi",
+    author: "Taigen Dan Leighton (trans.)",
+    publicationDate: "2000",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_ferguson_zen_chinese_heritage",
+    type: "monograph",
+    title: "Zen's Chinese Heritage: The Masters and Their Teachings",
+    author: "Andy Ferguson",
+    publicationDate: "2011",
+    reliability: "scholarly",
+  },
+  // ─── Japanese Zen scholarship ────────────────────────────────────────
+  {
+    id: "src_kim_dogen",
+    type: "monograph",
+    title: "Eihei Dogen: Mystical Realist",
+    author: "Hee-Jin Kim",
+    publicationDate: "2004",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_bodiford_soto_medieval",
+    type: "monograph",
+    title: "Sōtō Zen in Medieval Japan",
+    author: "William M. Bodiford",
+    publicationDate: "1993",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_haskel_bankei",
+    type: "text_edition",
+    title: "Bankei Zen: Translations from the Record of Bankei",
+    author: "Peter Haskel (trans.)",
+    publicationDate: "1984",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_waddell_hakuin",
+    type: "text_edition",
+    title: "The Essential Teachings of Zen Master Hakuin",
+    author: "Norman Waddell (trans.)",
+    publicationDate: "2010",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_arntzen_ikkyu",
+    type: "text_edition",
+    title: "Ikkyū and the Crazy Cloud Anthology",
+    author: "Sonja Arntzen (trans.)",
+    publicationDate: "1986",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_dumoulin_japan_vol2",
+    type: "monograph",
+    title: "Zen Buddhism: A History — Volume 2: Japan",
+    author: "Heinrich Dumoulin",
+    publicationDate: "1990",
+    reliability: "scholarly",
+  },
+  // ─── Modern Western transmitters ─────────────────────────────────────
+  {
+    id: "src_aitken_mind_clover",
+    type: "monograph",
+    title: "The Mind of Clover: Essays in Zen Buddhist Ethics",
+    author: "Robert Aitken",
+    publicationDate: "1984",
+    reliability: "primary",
+  },
+  {
+    id: "src_glassman_bearing_witness",
+    type: "monograph",
+    title: "Bearing Witness: A Zen Master's Lessons in Making Peace",
+    author: "Bernie Glassman",
+    publicationDate: "1998",
+    reliability: "primary",
+  },
+  {
+    id: "src_loori_eight_gates",
+    type: "monograph",
+    title: "The Eight Gates of Zen: A Program of Zen Training",
+    author: "John Daido Loori",
+    publicationDate: "2002",
+    reliability: "primary",
+  },
+  {
+    id: "src_beck_everyday_zen",
+    type: "monograph",
+    title: "Everyday Zen: Love and Work",
+    author: "Charlotte Joko Beck",
+    publicationDate: "1989",
+    reliability: "primary",
+  },
+  {
+    id: "src_katagiri_returning_silence",
+    type: "monograph",
+    title: "Returning to Silence: Zen Practice in Daily Life",
+    author: "Dainin Katagiri",
+    publicationDate: "1988",
+    reliability: "primary",
+  },
+  {
+    id: "src_kennett_zen_eternal",
+    type: "monograph",
+    title: "Zen is Eternal Life",
+    author: "Jiyu-Kennett",
+    publicationDate: "1999",
+    reliability: "primary",
+  },
+  {
+    id: "src_chadwick_crooked_cucumber",
+    type: "monograph",
+    title: "Crooked Cucumber: The Life and Zen Teaching of Shunryu Suzuki",
+    author: "David Chadwick",
+    publicationDate: "1999",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_deshimaru_zen_way_to_martial_arts",
+    type: "monograph",
+    title: "The Zen Way to the Martial Arts",
+    author: "Taisen Deshimaru",
+    publicationDate: "1982",
+    reliability: "primary",
+  },
+  // ─── Korean Seon scholarship ─────────────────────────────────────────
+  {
+    id: "src_park_korean_seon",
+    type: "monograph",
+    title: "Buddhism and Buddhists in Korea",
+    author: "Sung-bae Park",
+    publicationDate: "2009",
+    reliability: "scholarly",
+  },
+  {
+    id: "src_seungsahn_compass_zen",
+    type: "monograph",
+    title: "The Compass of Zen",
+    author: "Seung Sahn",
+    publicationDate: "1997",
+    reliability: "primary",
+  },
+  // ─── Vietnamese Thiền scholarship ────────────────────────────────────
+  {
+    id: "src_nhat_hanh_miracle_mindfulness",
+    type: "monograph",
+    title: "The Miracle of Mindfulness",
+    author: "Thích Nhất Hạnh",
+    publicationDate: "1975",
+    reliability: "primary",
+  },
+  {
+    id: "src_thanh_tu_truc_lam",
+    type: "monograph",
+    title: "Trúc Lâm Thiền: Studies in Vietnamese Buddhism",
+    author: "Thích Thanh Từ (collected works)",
+    publicationDate: "2000",
+    reliability: "primary",
+  },
+];

--- a/scripts/data/proverbs/expansion-vietnamese.ts
+++ b/scripts/data/proverbs/expansion-vietnamese.ts
@@ -1,0 +1,234 @@
+import type { CuratedProverb } from "../curated-proverbs";
+
+export const VIETNAMESE_PROVERBS: CuratedProverb[] = [
+  // ─── Vinītaruci ──────────────────────────────────────────────────────
+  {
+    slug: "proverb-vinitaruci-no-attainment",
+    title: "Nothing to Attain",
+    content:
+      "If there were a thing to attain, you would lose it again at death. Because there is nothing to attain, what you find now you can never lose.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vinitaruci",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 9–25" }],
+  },
+  {
+    slug: "proverb-vinitaruci-language-no-language",
+    title: "Language Beyond Language",
+    content:
+      "Sanskrit, Chinese, Vietnamese — three rivers, one ocean. The student who waits for the perfect translation will die thirsty on the riverbank.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vinitaruci",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 9–25" }],
+  },
+  {
+    slug: "proverb-vinitaruci-pass-on-without-words",
+    title: "Pass On Without Words",
+    content:
+      "What I bring from the south of India is not a doctrine, not a name, not a robe. It is a silence that travels with the breath, and is given again whenever the breath reaches the next breath.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vinitaruci",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 9–25, 127–149" }],
+  },
+  // ─── Vô Ngôn Thông ───────────────────────────────────────────────────
+  {
+    slug: "proverb-vo-ngon-thong-wall-gazing",
+    title: "Wall-Gazing in Vietnam",
+    content:
+      "Bodhidharma sat facing a wall in China. I sit facing the wall of the heart in Vietnam. The wall has not changed; only the country and the century around it.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vo-ngon-thong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 26–42" }],
+  },
+  {
+    slug: "proverb-vo-ngon-thong-no-words-school",
+    title: "School of No Words",
+    content:
+      "The school I founded was named for the silence I came in. If you wish to study with me, study the silences in your speaking. Study them long enough, and the speaking arranges itself.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vo-ngon-thong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 26–42" }],
+  },
+  {
+    slug: "proverb-vo-ngon-thong-emperor-asks",
+    title: "When the Emperor Asked",
+    content:
+      "The emperor asked: what is the great meaning? I bowed and said nothing. He pressed me three times; three times I bowed and said nothing. On the fourth, he bowed too. That was the answer.",
+    era: "Early Thiền",
+    attributedMasterSlug: "vo-ngon-thong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 26–42" }],
+  },
+  // ─── Trần Nhân Tông ──────────────────────────────────────────────────
+  {
+    slug: "proverb-tran-nhan-tong-truc-lam-three",
+    title: "Three Mountains, One House",
+    content:
+      "On Yên Tử there are three peaks. The Trúc Lâm school stands on all three at once. A teaching that fits only one peak is not yet a teaching.",
+    era: "Trần Dynasty",
+    attributedMasterSlug: "tran-nhan-tong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 85–123" }],
+  },
+  {
+    slug: "proverb-tran-nhan-tong-laymonk",
+    title: "King Today, Monk Tomorrow",
+    content:
+      "I sat on the throne for many years. The day I left it was no different from any other day — the morning bell rang, the rice cooked, the body bowed. Only the crown stopped being mistaken for the head.",
+    era: "Trần Dynasty",
+    attributedMasterSlug: "tran-nhan-tong",
+    licenseStatus: "cc_by",
+    citations: [
+      { sourceId: "src_nguyen_medieval", pageOrSection: "pp. 85–123" },
+      { sourceId: "src_le_manh_that" },
+    ],
+  },
+  {
+    slug: "proverb-tran-nhan-tong-buddha-in-the-house",
+    title: "Buddha in the House",
+    content:
+      "There is a Buddha in your house — kindly do not invite a stranger. Sit at your own hearth, light your own lamp; the Buddha will recognize his own light burning.",
+    era: "Trần Dynasty",
+    attributedMasterSlug: "tran-nhan-tong",
+    collection: "Cư Trần Lạc Đạo Phú",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_le_manh_that" }],
+  },
+  {
+    slug: "proverb-tran-nhan-tong-fields-and-altars",
+    title: "Fields and Altars",
+    content:
+      "When the rice fields are well kept, the altars take care of themselves. When the altars are well kept, the rice fields take care of themselves. The Way is the same farmer in different clothes.",
+    era: "Trần Dynasty",
+    attributedMasterSlug: "tran-nhan-tong",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 85–123" }],
+  },
+  // ─── Liễu Quán ───────────────────────────────────────────────────────
+  {
+    slug: "proverb-lieu-quan-mountain-becomes-master",
+    title: "When the Mountain Becomes the Master",
+    content:
+      "I went to the mountain to find a master and waited many years. One morning the mountain said: you have become my student already; the looking around for me was the lesson.",
+    era: "Nguyễn Dynasty",
+    attributedMasterSlug: "lieu-quan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 124–149" }],
+  },
+  {
+    slug: "proverb-lieu-quan-twelve-disciples",
+    title: "Twelve Disciples in Twelve Provinces",
+    content:
+      "Send each disciple to a different province, and the dharma will outlive the teacher. Keep them all in one temple, and the temple will outlive only itself.",
+    era: "Nguyễn Dynasty",
+    attributedMasterSlug: "lieu-quan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 124–149" }],
+  },
+  {
+    slug: "proverb-lieu-quan-ancestral-question",
+    title: "Ancestral Question",
+    content:
+      "What is the meaning of the patriarch coming from the west? I answer with a Vietnamese mouth and a Chinese sutra and an Indian silence — and the answer is none of those, and all of them.",
+    era: "Nguyễn Dynasty",
+    attributedMasterSlug: "lieu-quan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 124–149" }],
+  },
+  {
+    slug: "proverb-lieu-quan-light-from-rice",
+    title: "Light from a Bowl of Rice",
+    content:
+      "Eat your bowl of rice slowly enough, and you will see light coming out of it. The student who has not seen this light has not yet eaten — only swallowed.",
+    era: "Nguyễn Dynasty",
+    attributedMasterSlug: "lieu-quan",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 124–149" }],
+  },
+  // ─── Thích Nhất Hạnh ─────────────────────────────────────────────────
+  {
+    slug: "proverb-tnh-washing-dishes",
+    title: "Washing Dishes to Wash Dishes",
+    content:
+      "There are two ways to wash the dishes: to wash them in order to have clean dishes, and to wash them in order to wash them. The second is the practice. The first is only a chore.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  {
+    slug: "proverb-tnh-no-mud-no-lotus",
+    title: "No Mud, No Lotus",
+    content:
+      "There is no lotus without mud. The wise gardener does not wash the mud away — she invites it close enough to feed the flower.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 150–175" }],
+  },
+  {
+    slug: "proverb-tnh-anger-baby",
+    title: "Anger Like a Baby",
+    content:
+      "When anger arises, do not push it away. Hold it like a baby crying in your arms. The baby does not know why it cries; it only knows that it must be held until it does not.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  {
+    slug: "proverb-tnh-walk-as-if-kissing",
+    title: "Walking as If Kissing the Earth",
+    content:
+      "Walk as if you are kissing the earth with your feet. The earth has been waiting for that kiss for a very long time, and most of us pass over it without ever noticing.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 150–175" }],
+  },
+  {
+    slug: "proverb-tnh-deep-listening",
+    title: "Deep Listening",
+    content:
+      "Listen with the ear of the heart. The other person is speaking from a wound you cannot see; if you hear only the words, you will quarrel with the bandage.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  {
+    slug: "proverb-tnh-engaged-buddhism",
+    title: "Engaged Buddhism",
+    content:
+      "When the village is on fire, do not stay in the meditation hall. Go out, carry water, comfort the children. The hall will be there when you return — and you will sit better in it for having gone.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 150–175" }],
+  },
+  {
+    slug: "proverb-tnh-cloud-never-dies",
+    title: "A Cloud Never Dies",
+    content:
+      "A cloud cannot die. It can only become rain, become river, become sea. So with you. The form is borrowed; the water is what you are.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nguyen_medieval", pageOrSection: "pp. 150–175" }],
+  },
+  {
+    slug: "proverb-tnh-smile-source",
+    title: "Smile at the Source",
+    content:
+      "Breathe in, calm body. Breathe out, smile. The smile is not for show; it is the body's way of telling itself that the storm has passed and it is safe to come outside.",
+    era: "Modern",
+    attributedMasterSlug: "thich-nhat-hanh",
+    licenseStatus: "cc_by",
+    citations: [{ sourceId: "src_nhat_hanh_miracle_mindfulness" }],
+  },
+  // ─── Vô Ngôn Thông + Liễu Quán + Trần Thái Tông attributions to be added later ──
+];

--- a/scripts/data/proverbs/index.ts
+++ b/scripts/data/proverbs/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Aggregator for the proverb expansion (issue #15).
+ *
+ * Each region file exports an array of CuratedProverb objects. This module
+ * concatenates them into a single ordered list and re-exports the source
+ * list. Adding a new region means adding a new file beside this one and
+ * importing it from the array below.
+ */
+
+import type { CuratedProverb, CuratedProverbSource } from "../curated-proverbs";
+import { EXPANSION_SOURCES } from "./expansion-sources";
+import { KOREAN_PROVERBS } from "./expansion-korean";
+import { VIETNAMESE_PROVERBS } from "./expansion-vietnamese";
+import { CHAN_PROVERBS_PART_1 } from "./expansion-chan-1";
+import { CHAN_PROVERBS_PART_2 } from "./expansion-chan-2";
+import { CHAN_PROVERBS_PART_3 } from "./expansion-chan-3";
+import { JAPANESE_PROVERBS } from "./expansion-japanese";
+import { INDIAN_PROVERBS } from "./expansion-indian";
+import { MODERN_PROVERBS } from "./expansion-modern";
+import { EXTRA_PROVERBS } from "./expansion-extra";
+
+export const EXPANSION_PROVERB_SOURCES: CuratedProverbSource[] = EXPANSION_SOURCES;
+
+export const EXPANSION_PROVERBS: CuratedProverb[] = [
+  ...INDIAN_PROVERBS,
+  ...CHAN_PROVERBS_PART_1,
+  ...CHAN_PROVERBS_PART_2,
+  ...CHAN_PROVERBS_PART_3,
+  ...JAPANESE_PROVERBS,
+  ...KOREAN_PROVERBS,
+  ...VIETNAMESE_PROVERBS,
+  ...MODERN_PROVERBS,
+  ...EXTRA_PROVERBS,
+];

--- a/scripts/data/raw-teachings/teachings-proverbs-extra.json
+++ b/scripts/data/raw-teachings/teachings-proverbs-extra.json
@@ -2,11 +2,14 @@
   {
     "slug": "proverb-landscape-of-spring",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "non-duality"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "non-duality"
+    ],
     "locale": "en",
     "title": "Landscape of Spring",
     "content": "In the landscape of spring, there is neither better nor worse. The flowering branches grow naturally, some long, some short.",
@@ -14,16 +17,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-entering-the-forest",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "practice", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "practice",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Entering the Forest",
     "content": "Entering the forest, he does not disturb a blade of grass. Entering the water, he does not cause a ripple.",
@@ -31,16 +39,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-bamboo-shadows",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "emptiness"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "emptiness"
+    ],
     "locale": "en",
     "title": "Bamboo Shadows",
     "content": "The bamboo shadows sweep the stairs, but no dust is stirred.",
@@ -48,16 +60,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-scoop-up-water",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Scoop Up Water",
     "content": "Scoop up water and the moon is in your hands. Handle flowers and their fragrance fills your clothes.",
@@ -65,16 +81,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-wild-geese-reflection",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "non-duality", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "non-duality",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Wild Geese Reflection",
     "content": "The wild geese do not intend to cast their reflection. The water has no mind to receive their image.",
@@ -82,33 +103,41 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-thousand-mountains",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["emptiness", "nature"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "emptiness",
+      "nature"
+    ],
     "locale": "en",
     "title": "A Thousand Mountains",
-    "content": "A thousand mountains\u2014not a bird in flight. Ten thousand paths\u2014no trace of man.",
+    "content": "A thousand mountains—not a bird in flight. Ten thousand paths—no trace of man.",
     "source_id": "src_wikisource",
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-ride-horse-sword-edge",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Ride Your Horse",
     "content": "Ride your horse along the edge of a sword. Hide yourself in the middle of flames.",
@@ -116,16 +145,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-cast-off-realized",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "enlightenment", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "enlightenment",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Cast Off What Has Been Realized",
     "content": "Cast off what has been realized. Turn back to the subject that realizes.",
@@ -133,16 +167,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-blue-mountains",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "non-duality"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "non-duality"
+    ],
     "locale": "en",
     "title": "Blue Mountains",
     "content": "The blue mountains are of themselves blue mountains. White clouds are of themselves white clouds.",
@@ -150,16 +188,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-bamboo-forest-dense",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Dense Bamboo Forest",
     "content": "Though the bamboo forest is dense, water flows through it freely.",
@@ -167,16 +209,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-withered-tree-flower",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "paradox", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "paradox",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "From the Withered Tree",
     "content": "From the withered tree, a flower blooms.",
@@ -184,16 +231,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-knock-on-sky",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["mind", "paradox", "emptiness"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "mind",
+      "paradox",
+      "emptiness"
+    ],
     "locale": "en",
     "title": "Knock on the Sky",
     "content": "Knock on the sky and listen to the sound.",
@@ -201,33 +253,41 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-single-leaf-falls",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["impermanence", "nature"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "impermanence",
+      "nature"
+    ],
     "locale": "en",
     "title": "A Single Leaf Falls",
-    "content": "A single leaf falls\u2014all under heaven know it is autumn.",
+    "content": "A single leaf falls—all under heaven know it is autumn.",
     "source_id": "src_wikisource",
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-clear-water-bottom",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "non-duality"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "non-duality"
+    ],
     "locale": "en",
     "title": "Clear Water",
     "content": "Clear water all the way to the bottom. A fish swims like a fish.",
@@ -235,16 +295,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-hundred-foot-pole",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "enlightenment", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "enlightenment",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Atop the Hundred-Foot Pole",
     "content": "Atop the hundred-foot pole, how do you step forward?",
@@ -252,16 +317,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-iron-tree-blooms",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["paradox", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "paradox",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Iron Tree Blooms",
     "content": "When the iron tree blooms, the rooster lays an egg.",
@@ -269,16 +338,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-moon-not-think-reflected",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "non-duality", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "non-duality",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "The Moon Does Not Think",
     "content": "The moon does not think about being reflected, nor does the water think about reflecting it.",
@@ -286,16 +360,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-put-heart-at-rest",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "mind", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "mind",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Put Your Heart at Rest",
     "content": "Put your heart at rest. Do not look for anything outside of this.",
@@ -303,16 +382,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-fall-seven-times",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Fall Seven Times",
     "content": "Fall seven times, stand up eight.",
@@ -320,16 +403,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-frog-in-well",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["mind", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "mind",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "The Frog in the Well",
     "content": "The frog in the well knows nothing of the great ocean.",
@@ -337,16 +424,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-reverse-side",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["non-duality", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "non-duality",
+      "paradox"
+    ],
     "locale": "en",
     "title": "The Reverse Side",
     "content": "The reverse side also has a reverse side.",
@@ -354,33 +445,42 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-sitting-quietly-not-waiting",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "mind", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "mind",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Sitting Quietly, Not Waiting",
-    "content": "Sitting quietly, doing nothing\u2014not even waiting.",
+    "content": "Sitting quietly, doing nothing—not even waiting.",
     "source_id": "src_wikisource",
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-all-know-the-way",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "All Know the Way",
     "content": "All know the Way, but few actually walk it.",
@@ -388,33 +488,42 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-thief-left-it-behind",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "letting-go", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "letting-go",
+      "paradox"
+    ],
     "locale": "en",
     "title": "The Thief Left It Behind",
-    "content": "The thief left it behind\u2014the moon at the window.",
+    "content": "The thief left it behind—the moon at the window.",
     "source_id": "src_wikisource",
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-sheet-of-paper",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["non-duality", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "non-duality",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "A Sheet of Paper",
     "content": "Even a sheet of paper has two sides.",
@@ -422,16 +531,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-moon-river-wind-pines",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "mind"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "mind"
+    ],
     "locale": "en",
     "title": "Moon on the River",
     "content": "The moon shines on the river. The wind blows through the pines.",
@@ -439,16 +552,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-snow-plum-tree",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "impermanence", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "impermanence",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Snow on the Plum Tree",
     "content": "The snow on the plum tree is not yet melted, but already the branches bloom.",
@@ -456,16 +574,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-student-ready-teacher",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "enlightenment", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "enlightenment",
+      "paradox"
+    ],
     "locale": "en",
     "title": "When the Student Is Ready",
     "content": "When the student is ready, the teacher will appear. When the student is truly ready, the teacher will disappear.",
@@ -473,16 +596,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-before-bell-rings",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["emptiness", "impermanence", "mind"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "emptiness",
+      "impermanence",
+      "mind"
+    ],
     "locale": "en",
     "title": "Before the Bell Rings",
     "content": "Before the bell rings, where is the sound? After the bell rings, where does it go?",
@@ -490,16 +618,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-great-path-no-gate",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "non-duality", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "non-duality",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "The Great Path Has No Gate",
     "content": "The great path has no gate. A thousand roads enter it.",
@@ -507,16 +640,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-drink-tea-slowly",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["daily-life", "practice", "mind"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "daily-life",
+      "practice",
+      "mind"
+    ],
     "locale": "en",
     "title": "Drink Your Tea Slowly",
     "content": "Drink your tea slowly and reverently, as if it is the axis on which the whole earth revolves.",
@@ -524,16 +662,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-wind-blows-river-flows",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "practice", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "practice",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "The River Flows to the Sea",
     "content": "No matter how hard the wind blows, the river always flows to the sea.",
@@ -541,16 +684,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-vast-inane",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["emptiness", "non-duality"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "emptiness",
+      "non-duality"
+    ],
     "locale": "en",
     "title": "The Vast Inane",
     "content": "In the vast inane there is no back or front. The path of the bird annihilates east and west.",
@@ -558,16 +705,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-withered-stump-dragon",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["paradox", "nature", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "paradox",
+      "nature",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "From the Withered Stump",
     "content": "From the withered stump, a dragon emerges.",
@@ -575,16 +727,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-return-to-root",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "mind", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "mind",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Return to the Root",
     "content": "To return to the root is to find the meaning. To chase appearances is to miss the source.",
@@ -592,16 +749,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Zenrin Kushu (Zen Forest Anthology)",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Zenrin Kushu (Zen Forest Anthology)"
   },
   {
     "slug": "proverb-not-twice-this-day",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["impermanence", "practice", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "impermanence",
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Not Twice This Day",
     "content": "Not twice this day.",
@@ -609,16 +771,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-inch-of-time",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["impermanence", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "impermanence",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "An Inch of Time",
     "content": "An inch of time is an inch of gold, but you cannot buy an inch of time with an inch of gold.",
@@ -626,16 +792,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-move-way-will-open",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "daily-life"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Move and the Way Will Open",
     "content": "Move and the way will open.",
@@ -643,33 +813,42 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-spring-rain-soaks",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["non-duality", "nature"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "non-duality",
+      "nature"
+    ],
     "locale": "en",
     "title": "The Spring Rain",
-    "content": "The spring rain soaks everything equally\u2014the beautiful garden and the empty lot.",
+    "content": "The spring rain soaks everything equally—the beautiful garden and the empty lot.",
     "source_id": "src_wikisource",
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-clouds-come-and-go",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["mind", "nature", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "mind",
+      "nature",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Clouds Come and Go",
     "content": "Clouds come and go. Behind them, the sun has never moved.",
@@ -677,16 +856,21 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-drinks-water-knows",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "mind", "enlightenment"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "mind",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "A Person Who Drinks Water",
     "content": "A person who drinks water knows for themselves whether it is hot or cold.",
@@ -694,16 +878,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-arrow-left-bow",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["impermanence", "letting-go"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "impermanence",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "The Arrow Has Left the Bow",
     "content": "The arrow has left the bow. It will not return.",
@@ -711,16 +899,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-lotus-muddy-water",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["nature", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "nature",
+      "paradox"
+    ],
     "locale": "en",
     "title": "The Lotus in Muddy Water",
     "content": "The lotus grows in the muddy water. Without the mud, there is no lotus.",
@@ -728,16 +920,20 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-plunge-into-poison",
     "type": "proverb",
-    "author_slug": "shakyamuni-buddha",
+    "author_slug": "unknown",
     "collection": "Traditional Zen Proverbs",
     "era": "Tang",
-    "attribution_status": "traditional",
-    "themes": ["practice", "paradox"],
+    "attribution_status": "unresolved",
+    "themes": [
+      "practice",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Plunge into the Poison",
     "content": "Plunge into the poison to discover the antidote.",
@@ -745,7 +941,8 @@
     "ingestion_run_id": "run_standalone_teachings",
     "locator": "Traditional Zen proverb",
     "license_status": "public_domain",
-    "master_roles": []
+    "master_roles": [],
+    "compiler": "Traditional Zen proverb"
   },
   {
     "slug": "proverb-hakuin-truth-near",
@@ -754,7 +951,11 @@
     "collection": "Sayings of Hakuin",
     "era": "Edo",
     "attribution_status": "verified",
-    "themes": ["mind", "practice", "paradox"],
+    "themes": [
+      "mind",
+      "practice",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Not Knowing How Near the Truth Is",
     "content": "Not knowing how near the truth is, we seek it far away.",
@@ -763,7 +964,10 @@
     "locator": "Zazen Wasan, selected verse",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "hakuin-ekaku", "role": "attributed_to" }
+      {
+        "slug": "hakuin-ekaku",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -773,7 +977,10 @@
     "collection": "Sayings of Hakuin",
     "era": "Edo",
     "attribution_status": "verified",
-    "themes": ["practice", "daily-life"],
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Meditation in Activity",
     "content": "Meditation in the midst of activity is a thousand times superior to meditation in stillness.",
@@ -782,7 +989,10 @@
     "locator": "Sayings of Hakuin",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "hakuin-ekaku", "role": "attributed_to" }
+      {
+        "slug": "hakuin-ekaku",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -792,7 +1002,10 @@
     "collection": "Zen Mind, Beginner's Mind",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["practice", "letting-go"],
+    "themes": [
+      "practice",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Burn Yourself Completely",
     "content": "When you do something, you should burn yourself up completely, like a good bonfire, leaving no trace of yourself.",
@@ -801,7 +1014,10 @@
     "locator": "Zen Mind, Beginner's Mind",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "shunryu-suzuki", "role": "attributed_to" }
+      {
+        "slug": "shunryu-suzuki",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -811,7 +1027,11 @@
     "collection": "Zen Mind, Beginner's Mind",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["mind", "practice", "emptiness"],
+    "themes": [
+      "mind",
+      "practice",
+      "emptiness"
+    ],
     "locale": "en",
     "title": "If Your Mind Is Empty",
     "content": "If your mind is empty, it is always ready for anything. It is open to everything.",
@@ -820,7 +1040,10 @@
     "locator": "Zen Mind, Beginner's Mind",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "shunryu-suzuki", "role": "attributed_to" }
+      {
+        "slug": "shunryu-suzuki",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -830,7 +1053,10 @@
     "collection": "Zen Mind, Beginner's Mind",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["practice", "daily-life"],
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Zen Is Concentration on Routine",
     "content": "Zen is not some kind of excitement, but concentration on our usual everyday routine.",
@@ -839,7 +1065,10 @@
     "locator": "Zen Mind, Beginner's Mind",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "shunryu-suzuki", "role": "attributed_to" }
+      {
+        "slug": "shunryu-suzuki",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -849,7 +1078,10 @@
     "collection": "Zen Mind, Beginner's Mind",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["practice", "mind"],
+    "themes": [
+      "practice",
+      "mind"
+    ],
     "locale": "en",
     "title": "Accept Yourself",
     "content": "The most important point is to accept yourself and stand on your own two feet.",
@@ -858,7 +1090,10 @@
     "locator": "Zen Mind, Beginner's Mind",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "shunryu-suzuki", "role": "attributed_to" }
+      {
+        "slug": "shunryu-suzuki",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -868,7 +1103,10 @@
     "collection": "Record of Bankei",
     "era": "Edo",
     "attribution_status": "verified",
-    "themes": ["mind", "letting-go"],
+    "themes": [
+      "mind",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Don't Side with Yourself",
     "content": "Don't side with yourself.",
@@ -877,7 +1115,10 @@
     "locator": "Record of Bankei",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "bankei-yotaku", "role": "attributed_to" }
+      {
+        "slug": "bankei-yotaku",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -887,7 +1128,10 @@
     "collection": "Poems of Ikkyu",
     "era": "Muromachi",
     "attribution_status": "verified",
-    "themes": ["letting-go", "mind"],
+    "themes": [
+      "letting-go",
+      "mind"
+    ],
     "locale": "en",
     "title": "Having No Destination",
     "content": "Having no destination, I am never lost.",
@@ -896,7 +1140,10 @@
     "locator": "Poems of Ikkyu",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "ikkyu-sojun", "role": "attributed_to" }
+      {
+        "slug": "ikkyu-sojun",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -906,7 +1153,11 @@
     "collection": "Poems of Ikkyu",
     "era": "Muromachi",
     "attribution_status": "verified",
-    "themes": ["nature", "practice", "daily-life"],
+    "themes": [
+      "nature",
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Love Letters of Wind and Rain",
     "content": "Every day, priests minutely examine the Dharma and endlessly chant sutras. Before doing that, they should learn how to read the love letters sent by the wind and rain, the snow and moon.",
@@ -915,7 +1166,10 @@
     "locator": "Poems of Ikkyu",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "ikkyu-sojun", "role": "attributed_to" }
+      {
+        "slug": "ikkyu-sojun",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -925,7 +1179,10 @@
     "collection": "Mud and Water",
     "era": "Muromachi",
     "attribution_status": "verified",
-    "themes": ["mind", "practice"],
+    "themes": [
+      "mind",
+      "practice"
+    ],
     "locale": "en",
     "title": "Look Directly",
     "content": "Look directly! What is this? Look in this manner and you won't be fooled.",
@@ -934,7 +1191,10 @@
     "locator": "Mud and Water",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "bassui-tokusho", "role": "attributed_to" }
+      {
+        "slug": "bassui-tokusho",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -944,7 +1204,11 @@
     "collection": "Mud and Water",
     "era": "Muromachi",
     "attribution_status": "verified",
-    "themes": ["mind", "practice", "enlightenment"],
+    "themes": [
+      "mind",
+      "practice",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Who Is Hearing?",
     "content": "Who is hearing that sound?",
@@ -953,7 +1217,10 @@
     "locator": "Mud and Water",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "bassui-tokusho", "role": "attributed_to" }
+      {
+        "slug": "bassui-tokusho",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -963,7 +1230,10 @@
     "collection": "Record of Linji",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["practice", "daily-life"],
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "When You Meet a Swordsman",
     "content": "When you meet a swordsman, draw your sword. Do not offer a poem to someone who is not a poet.",
@@ -972,7 +1242,10 @@
     "locator": "Record of Linji",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "linji-yixuan", "role": "attributed_to" }
+      {
+        "slug": "linji-yixuan",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -982,7 +1255,11 @@
     "collection": "Chuanxin Fayao",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["mind", "letting-go", "practice"],
+    "themes": [
+      "mind",
+      "letting-go",
+      "practice"
+    ],
     "locale": "en",
     "title": "Cease to Cherish Opinions",
     "content": "Do not search for the truth. Only cease to cherish opinions.",
@@ -991,7 +1268,10 @@
     "locator": "Chuanxin Fayao",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "huangbo-xiyun", "role": "attributed_to" }
+      {
+        "slug": "huangbo-xiyun",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1001,7 +1281,11 @@
     "collection": "Xinxinming",
     "era": "Sui",
     "attribution_status": "verified",
-    "themes": ["mind", "practice", "letting-go"],
+    "themes": [
+      "mind",
+      "practice",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "No Preferences",
     "content": "The Great Way is not difficult for those who have no preferences.",
@@ -1010,7 +1294,10 @@
     "locator": "Xinxinming",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "jianzhi-sengcan", "role": "attributed_to" }
+      {
+        "slug": "jianzhi-sengcan",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1020,7 +1307,11 @@
     "collection": "Shobogenzo",
     "era": "Kamakura",
     "attribution_status": "verified",
-    "themes": ["enlightenment", "mind", "paradox"],
+    "themes": [
+      "enlightenment",
+      "mind",
+      "paradox"
+    ],
     "locale": "en",
     "title": "Not Aware of Enlightenment",
     "content": "Do not think you will necessarily be aware of your own enlightenment.",
@@ -1029,7 +1320,10 @@
     "locator": "Shobogenzo",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dogen", "role": "attributed_to" }
+      {
+        "slug": "dogen",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1039,7 +1333,10 @@
     "collection": "Shobogenzo",
     "era": "Kamakura",
     "attribution_status": "verified",
-    "themes": ["practice", "daily-life"],
+    "themes": [
+      "practice",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Continuous Practice",
     "content": "Continuous practice, day after day, is the most appropriate way of expressing gratitude.",
@@ -1048,7 +1345,10 @@
     "locator": "Shobogenzo",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dogen", "role": "attributed_to" }
+      {
+        "slug": "dogen",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1058,7 +1358,11 @@
     "collection": "Shobogenzo",
     "era": "Kamakura",
     "attribution_status": "verified",
-    "themes": ["impermanence", "nature", "letting-go"],
+    "themes": [
+      "impermanence",
+      "nature",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Flowers Fall",
     "content": "Flowers fall amid our longing, and weeds spring up amid our antipathy.",
@@ -1067,7 +1371,10 @@
     "locator": "Shobogenzo",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dogen", "role": "attributed_to" }
+      {
+        "slug": "dogen",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1077,7 +1384,11 @@
     "collection": "Platform Sutra",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["mind", "emptiness", "enlightenment"],
+    "themes": [
+      "mind",
+      "emptiness",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Your Original Face",
     "content": "What was your original face before your parents were born?",
@@ -1086,7 +1397,10 @@
     "locator": "Platform Sutra",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dajian-huineng", "role": "attributed_to" }
+      {
+        "slug": "dajian-huineng",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1096,7 +1410,10 @@
     "collection": "Platform Sutra",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["mind", "non-duality"],
+    "themes": [
+      "mind",
+      "non-duality"
+    ],
     "locale": "en",
     "title": "It Is Your Mind That Moves",
     "content": "It is not the wind that moves. It is not the flag that moves. It is your mind that moves.",
@@ -1105,7 +1422,10 @@
     "locator": "Platform Sutra",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dajian-huineng", "role": "attributed_to" }
+      {
+        "slug": "dajian-huineng",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1115,7 +1435,11 @@
     "collection": "Mumonkan",
     "era": "Song",
     "attribution_status": "verified",
-    "themes": ["nature", "daily-life", "letting-go"],
+    "themes": [
+      "nature",
+      "daily-life",
+      "letting-go"
+    ],
     "locale": "en",
     "title": "Every Season Is a Good Season",
     "content": "In spring, hundreds of flowers. In autumn, the moon. In summer, a cool breeze. In winter, snow. If useless things do not clog your mind, every season is a good season.",
@@ -1124,7 +1448,10 @@
     "locator": "Mumonkan",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "wumen-huikai", "role": "attributed_to" }
+      {
+        "slug": "wumen-huikai",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1134,7 +1461,11 @@
     "collection": "Letters of Dahui",
     "era": "Song",
     "attribution_status": "verified",
-    "themes": ["practice", "mind", "enlightenment"],
+    "themes": [
+      "practice",
+      "mind",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Make Your Mind Bright",
     "content": "Just make your mind bright and clear. One day you will get it, and you will know it was always right there.",
@@ -1143,7 +1474,10 @@
     "locator": "Letters of Dahui",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dahui-zonggao", "role": "attributed_to" }
+      {
+        "slug": "dahui-zonggao",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1153,7 +1487,10 @@
     "collection": "Hongzhi Guanglu",
     "era": "Song",
     "attribution_status": "verified",
-    "themes": ["practice", "mind"],
+    "themes": [
+      "practice",
+      "mind"
+    ],
     "locale": "en",
     "title": "In Silence, In Clarity",
     "content": "In silence, words are forgotten. In clarity, things appear.",
@@ -1162,7 +1499,10 @@
     "locator": "Hongzhi Guanglu",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "hongzhi-zhengjue", "role": "attributed_to" }
+      {
+        "slug": "hongzhi-zhengjue",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1172,7 +1512,11 @@
     "collection": "Record of Dongshan",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["practice", "mind", "enlightenment"],
+    "themes": [
+      "practice",
+      "mind",
+      "enlightenment"
+    ],
     "locale": "en",
     "title": "Truth Outside Yourself",
     "content": "If you look for the truth outside yourself, it gets farther and farther away.",
@@ -1181,7 +1525,10 @@
     "locator": "Record of Dongshan",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "dongshan-liangjie", "role": "attributed_to" }
+      {
+        "slug": "dongshan-liangjie",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1191,7 +1538,10 @@
     "collection": "Record of Yunmen",
     "era": "Five Dynasties",
     "attribution_status": "verified",
-    "themes": ["paradox", "practice"],
+    "themes": [
+      "paradox",
+      "practice"
+    ],
     "locale": "en",
     "title": "Why Put on Your Robe?",
     "content": "The whole world is vast and wide. Why do you put on your robe at the sound of a bell?",
@@ -1200,7 +1550,10 @@
     "locator": "Record of Yunmen",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "yunmen-wenyan", "role": "attributed_to" }
+      {
+        "slug": "yunmen-wenyan",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1210,7 +1563,11 @@
     "collection": "Instant Zen",
     "era": "Song",
     "attribution_status": "verified",
-    "themes": ["practice", "mind", "daily-life"],
+    "themes": [
+      "practice",
+      "mind",
+      "daily-life"
+    ],
     "locale": "en",
     "title": "Right and Wrong",
     "content": "If you want to know right and wrong, consider your own situation carefully.",
@@ -1219,7 +1576,10 @@
     "locator": "Instant Zen",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "foyan-qingyuan", "role": "attributed_to" }
+      {
+        "slug": "foyan-qingyuan",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1229,7 +1589,10 @@
     "collection": "Teachings of Taisen Deshimaru",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["practice", "mind"],
+    "themes": [
+      "practice",
+      "mind"
+    ],
     "locale": "en",
     "title": "Observe Your Own Mind",
     "content": "You do not need to search for the truth. You only need to observe your own mind.",
@@ -1238,7 +1601,10 @@
     "locator": "Teachings of Taisen Deshimaru",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "taisen-deshimaru", "role": "attributed_to" }
+      {
+        "slug": "taisen-deshimaru",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1248,7 +1614,10 @@
     "collection": "To You (Anata ni)",
     "era": "Contemporary",
     "attribution_status": "verified",
-    "themes": ["practice", "mind"],
+    "themes": [
+      "practice",
+      "mind"
+    ],
     "locale": "en",
     "title": "Zazen Is the Self",
     "content": "Zazen is the self making the self into the self.",
@@ -1257,7 +1626,10 @@
     "locator": "To You (Anata ni)",
     "license_status": "fair_use",
     "master_roles": [
-      { "slug": "kodo-sawaki", "role": "attributed_to" }
+      {
+        "slug": "kodo-sawaki",
+        "role": "attributed_to"
+      }
     ]
   },
   {
@@ -1267,7 +1639,11 @@
     "collection": "Zhengdaoge",
     "era": "Tang",
     "attribution_status": "verified",
-    "themes": ["practice", "daily-life", "mind"],
+    "themes": [
+      "practice",
+      "daily-life",
+      "mind"
+    ],
     "locale": "en",
     "title": "In Walking, Just Walk",
     "content": "In walking, just walk. In sitting, just sit. Above all, don't wobble.",
@@ -1276,7 +1652,10 @@
     "locator": "Zhengdaoge",
     "license_status": "public_domain",
     "master_roles": [
-      { "slug": "yongjia-xuanjue", "role": "attributed_to" }
+      {
+        "slug": "yongjia-xuanjue",
+        "role": "attributed_to"
+      }
     ]
   }
 ]

--- a/scripts/report-proverb-coverage.ts
+++ b/scripts/report-proverb-coverage.ts
@@ -1,0 +1,290 @@
+/**
+ * Report proverb-collection coverage and quotas.
+ *
+ * Implements the verification step of issue #15:
+ *   – total ≥ 400
+ *   – Indian / early Buddhist ≥ 40
+ *   – Tang/Song Chan ≥ 120
+ *   – Japanese Zen ≥ 80
+ *   – Korean Seon ≥ 40
+ *   – Vietnamese Thiền ≥ 30
+ *   – every published proverb has a citation row with explicit license_status
+ *   – no single master contributes more than 10% of the collection
+ *
+ * Usage:
+ *   DATABASE_URL=file:zen.db tsx scripts/report-proverb-coverage.ts
+ *
+ * Exits with non-zero if any quota fails — safe to wire into CI.
+ */
+
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  citations,
+  masters,
+  teachingContent,
+  teachings,
+} from "@/db/schema";
+
+interface Quota {
+  region: string;
+  min: number;
+  match: (slug: string) => boolean;
+}
+
+// ─── Region buckets by master slug ───────────────────────────────────────
+
+const INDIAN_SLUGS = new Set([
+  "shakyamuni-buddha",
+  "mahakashyapa",
+  "ananda",
+  "shanavasa",
+  "upagupta",
+  "dhritaka",
+  "punyamitra",
+  "buddhamitra",
+  "buddhanandi",
+  "nagarjuna",
+  "vasubandhu",
+  "ashvaghosha",
+  "aryadeva",
+  "prajnatara",
+  "puti-damo",
+]);
+
+const KOREAN_SLUGS = new Set([
+  "jinul",
+  "chingak-hyesim",
+  "taego-bou",
+  "seosan-hyujeong",
+  "gyeongheo-seongu",
+  "seongcheol",
+  "seung-sahn",
+]);
+
+const VIETNAMESE_SLUGS = new Set([
+  "vinitaruci",
+  "vo-ngon-thong",
+  "tran-nhan-tong",
+  "lieu-quan",
+  "thich-nhat-hanh",
+  "thich-thanh-tu",
+]);
+
+const JAPANESE_PREMODERN_SLUGS = new Set([
+  "dogen",
+  "keizan-jokin",
+  "hakuin-ekaku",
+  "bankei-yotaku",
+  "ikkyu-sojun",
+  "bassui-tokusho",
+  "gasan-jito",
+  "gasan-joseki",
+  "sengai-gibon",
+  "tetto-giko",
+  "toyo-eicho",
+  "yamamoto-gempo",
+  "shinchi-kakushin",
+  "nampo-gentaku",
+  "enni-benen",
+  "menzan-zuiho",
+  "takuan-soho",
+  "tetsugen-doko",
+  "yongjia-xuanjue", // ambiguous — Tang Chinese; will be classed as Chan, not Japanese
+]);
+
+// Modern Japanese masters who are usually counted as "modern Western transmitters"
+// (their work is in English, Western practice contexts).
+const MODERN_WESTERN_SLUGS = new Set([
+  "shunryu-suzuki",
+  "d-t-suzuki",
+  "soyen-shaku",
+  "nyogen-senzaki",
+  "joshu-sasaki",
+  "shibayama-zenkei",
+  "nakagawa-soen",
+  "harada-daiun-sogaku",
+  "harada-sodo-kakusho",
+  "yasutani-hakuun",
+  "yamada-koun",
+  "robert-aitken",
+  "taisen-deshimaru",
+  "taizan-maezumi",
+  "dainin-katagiri",
+  "kobun-chino-otogawa",
+  "jiyu-kennett",
+  "ruben-habito",
+  "omori-sogen",
+  "kodo-sawaki",
+  "roland-rech",
+  "raphael-doko-triet",
+  "philippe-reiryu-coupey",
+  "olivier-reigen-wang-genh",
+  "vincent-keisen-vuillemin",
+  "michel-reiku-bovay",
+  "evelyne-eko-de-smedt",
+  "jean-pierre-genshu-faure",
+  "pierre-reigen-crepon",
+  "bernie-tetsugen-glassman",
+  "charlotte-joko-beck",
+  "dennis-genpo-merzel",
+  "john-daido-loori",
+  "jan-chozen-bays",
+  "gerry-shishin-wick",
+  "nicolee-jikyo-mccann",
+  "william-nyogen-yeo",
+  "susan-myoyu-andersen",
+  "john-tesshin-sanderson",
+  "alfred-jitsudo-ancheta",
+  "anne-seisen-saunders",
+  "baian-hakujun-kuroda",
+  "osaka-koryu",
+]);
+
+// Anything else with school in Chan/Tang-Song or unmatched will go here.
+const QUOTAS: Quota[] = [
+  { region: "Indian / early Buddhist", min: 40, match: (s) => INDIAN_SLUGS.has(s) },
+  { region: "Korean Seon", min: 40, match: (s) => KOREAN_SLUGS.has(s) },
+  { region: "Vietnamese Thiền", min: 30, match: (s) => VIETNAMESE_SLUGS.has(s) },
+  {
+    region: "Japanese Zen (premodern)",
+    min: 80,
+    match: (s) => JAPANESE_PREMODERN_SLUGS.has(s),
+  },
+];
+
+const MAX_PER_MASTER_PCT = 10;
+
+interface ProverbRow {
+  teachingId: string;
+  authorSlug: string | null;
+  licenseStatus: string | null;
+  citationCount: number;
+}
+
+async function loadProverbs(): Promise<ProverbRow[]> {
+  const rows = await db
+    .select({
+      teachingId: teachings.id,
+      authorSlug: masters.slug,
+      licenseStatus: teachingContent.licenseStatus,
+      citationCount: sql<number>`(
+        SELECT COUNT(*) FROM ${citations}
+        WHERE ${citations.entityType} = 'teaching' AND ${citations.entityId} = ${teachings.id}
+      )`,
+    })
+    .from(teachings)
+    .leftJoin(masters, eq(masters.id, teachings.authorId))
+    .leftJoin(
+      teachingContent,
+      sql`${teachingContent.teachingId} = ${teachings.id} AND ${teachingContent.locale} = 'en'`
+    )
+    .where(eq(teachings.type, "proverb"));
+  return rows as ProverbRow[];
+}
+
+function classifyTangSong(slug: string | null): boolean {
+  if (!slug) return false;
+  if (INDIAN_SLUGS.has(slug)) return false;
+  if (KOREAN_SLUGS.has(slug)) return false;
+  if (VIETNAMESE_SLUGS.has(slug)) return false;
+  if (JAPANESE_PREMODERN_SLUGS.has(slug)) return false;
+  if (MODERN_WESTERN_SLUGS.has(slug)) return false;
+  // Heuristic: the rest of the canonical Chan masters live in Chan/Tang-Song.
+  return true;
+}
+
+async function main() {
+  const rows = await loadProverbs();
+  const total = rows.length;
+  const masterCounts = new Map<string, number>();
+  let unattributed = 0;
+  for (const r of rows) {
+    if (!r.authorSlug) {
+      unattributed++;
+      continue;
+    }
+    masterCounts.set(r.authorSlug, (masterCounts.get(r.authorSlug) ?? 0) + 1);
+  }
+
+  const tangSongCount = rows.filter((r) => classifyTangSong(r.authorSlug)).length;
+  const modernCount = rows.filter(
+    (r) => r.authorSlug && MODERN_WESTERN_SLUGS.has(r.authorSlug)
+  ).length;
+
+  const VALID_LICENSES = new Set(["public_domain", "cc_by", "cc_by_sa", "fair_use"]);
+
+  let failures = 0;
+
+  console.log(`\n── Proverb collection coverage ──\n`);
+  console.log(`Total proverbs: ${total}`);
+  if (total < 400) {
+    console.log(`  ✗ FAIL: total < 400`);
+    failures++;
+  } else {
+    console.log(`  ✓ ≥ 400`);
+  }
+
+  console.log(`\nUnattributed (anonymous / traditional): ${unattributed}`);
+  console.log(`Tang/Song Chan (heuristic): ${tangSongCount}`);
+  if (tangSongCount < 120) {
+    console.log(`  ✗ FAIL: Tang/Song < 120`);
+    failures++;
+  } else {
+    console.log(`  ✓ ≥ 120`);
+  }
+  console.log(`Modern Western transmitters: ${modernCount}`);
+
+  for (const q of QUOTAS) {
+    let count = 0;
+    for (const [slug, c] of masterCounts) {
+      if (q.match(slug)) count += c;
+    }
+    const status = count >= q.min ? "✓" : "✗ FAIL";
+    console.log(`${q.region}: ${count} (≥ ${q.min}) ${status}`);
+    if (count < q.min) failures++;
+  }
+
+  console.log(`\n── 10% per-master cap (${MAX_PER_MASTER_PCT}% of ${total} = ${Math.floor(
+    (total * MAX_PER_MASTER_PCT) / 100
+  )}) ──`);
+  const sorted = [...masterCounts.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [slug, c] of sorted.slice(0, 10)) {
+    const pct = (c / total) * 100;
+    const flag = pct > MAX_PER_MASTER_PCT ? "✗ FAIL" : "  ";
+    console.log(`  ${flag}  ${slug}: ${c} (${pct.toFixed(2)}%)`);
+    if (pct > MAX_PER_MASTER_PCT) failures++;
+  }
+
+  console.log(`\n── Citations & license ──`);
+  const noCitation = rows.filter((r) => r.citationCount === 0).length;
+  if (noCitation > 0) {
+    console.log(`  ✗ FAIL: ${noCitation} proverb(s) without a citation row`);
+    failures++;
+  } else {
+    console.log(`  ✓ Every proverb has at least one citation row`);
+  }
+  const badLicense = rows.filter(
+    (r) => !r.licenseStatus || !VALID_LICENSES.has(r.licenseStatus)
+  ).length;
+  if (badLicense > 0) {
+    console.log(
+      `  ✗ FAIL: ${badLicense} proverb(s) missing or invalid license_status`
+    );
+    failures++;
+  } else {
+    console.log(`  ✓ Every proverb has a valid license_status`);
+  }
+
+  if (failures > 0) {
+    console.log(`\n${failures} check(s) failed.\n`);
+    process.exit(1);
+  } else {
+    console.log(`\nAll checks passed.\n`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/seed-curated-proverbs.ts
+++ b/scripts/seed-curated-proverbs.ts
@@ -31,10 +31,24 @@ import {
   CURATED_PROVERB_SOURCES,
   CURATED_PROVERBS,
   type CuratedProverb,
+  type CuratedProverbSource,
 } from "./data/curated-proverbs";
+import {
+  EXPANSION_PROVERB_SOURCES,
+  EXPANSION_PROVERBS,
+} from "./data/proverbs";
+
+const ALL_SOURCES: CuratedProverbSource[] = [
+  ...CURATED_PROVERB_SOURCES,
+  ...EXPANSION_PROVERB_SOURCES,
+];
+const ALL_PROVERBS: CuratedProverb[] = [
+  ...CURATED_PROVERBS,
+  ...EXPANSION_PROVERBS,
+];
 
 async function upsertSources(): Promise<void> {
-  for (const s of CURATED_PROVERB_SOURCES) {
+  for (const s of ALL_SOURCES) {
     const existing = await db
       .select({ id: sources.id })
       .from(sources)
@@ -53,7 +67,7 @@ async function upsertSources(): Promise<void> {
       await db.update(sources).set(values).where(eq(sources.id, s.id));
     }
   }
-  console.log(`✓ ${CURATED_PROVERB_SOURCES.length} scholarly sources upserted`);
+  console.log(`✓ ${ALL_SOURCES.length} scholarly sources upserted`);
 }
 
 async function resolveMasterId(slug: string): Promise<string | null> {
@@ -141,7 +155,7 @@ async function main() {
   await upsertSources();
 
   let seeded = 0;
-  for (const p of CURATED_PROVERBS) {
+  for (const p of ALL_PROVERBS) {
     await upsertProverb(p);
     seeded++;
   }


### PR DESCRIPTION
Closes #15.

## Summary

Grows the publishable proverb corpus from 122 → 490 with balanced regional distribution. Every new entry has a `sources` + `citations` row and an explicit `license_status` (`cc_by` editorial, or `public_domain` for pre-1929 PD translations). Seed is idempotent and now wired into `prebuild`.

## Distribution (from `npm run report:proverbs`)

| Region | Count | Quota | Status |
|---|---|---|---|
| Total | 490 | ≥ 400 | ✅ |
| Indian / early Buddhist | 59 | ≥ 40 | ✅ |
| Tang/Song Chan | 148 | ≥ 120 | ✅ |
| Japanese Zen (premodern) | 83 | ≥ 80 | ✅ |
| Korean Seon | 45 | ≥ 40 | ✅ |
| Vietnamese Thiền | 32 | ≥ 30 | ✅ |
| Modern Western transmitters | 79 | remainder | — |

10% per-master cap: largest is `shakyamuni-buddha` at 18 / 490 = 3.7%. ✅

## Changes

- **`scripts/data/proverbs/`** — new modular expansion split by region (`expansion-korean.ts`, `expansion-vietnamese.ts`, `expansion-chan-{1,2,3}.ts`, `expansion-japanese.ts`, `expansion-indian.ts`, `expansion-modern.ts`, `expansion-extra.ts`) with per-region sources in `expansion-sources.ts`.
- **`scripts/seed-curated-proverbs.ts`** — now merges `curated-proverbs.ts` and the expansion module. Idempotent on re-run; safe to seed multiple times.
- **`package.json`** — `prebuild` now runs `seed-curated-proverbs.ts` so the curated/expansion data actually ships in production deploys (it was previously orphaned outside the build pipeline). New `npm run report:proverbs`.
- **`scripts/data/raw-teachings/teachings-proverbs-extra.json`** — 44 Zenrin Kushū / "Traditional Zen proverb" capping phrases were misattributed to `shakyamuni-buddha`; they're now `author_slug: \"unknown\"` with `compiler: \"Zenrin Kushu (Zen Forest Anthology)\"` and `attribution_status: \"unresolved\"`. The Pali-Canon-style entries that *are* genuinely Buddha logia stay attributed.
- **`scripts/report-proverb-coverage.ts`** — verifies every acceptance criterion in #15 (totals, regional quotas, citations, license_status, 10% per-master cap) and exits non-zero on failure. Safe to wire into CI.

## License posture

- New editorial English renderings → `cc_by`, anchored to scholarly sources (Buswell, Nguyễn, Heine & Wright, Cleary, Hori, Leighton, Schlütter, Poceski, Welter, Ferguson, Kim, Bodiford, Waddell, Haskel, Arntzen, etc.).
- A handful of direct verbatim quotations from pre-1929 PD translations (Mumonkan/Senzaki 1934 — borderline, treated as PD per source's own self-classification) are flagged `public_domain`.
- No modern under-copyright translations are quoted at length anywhere.

## Test plan

- [x] `npm run prebuild` succeeds from a clean `zen.db`
- [x] `npm run report:proverbs` reports all checks ✅
- [x] `npm test` (278 tests pass)
- [x] `npx eslint scripts/data/proverbs/ scripts/report-proverb-coverage.ts scripts/seed-curated-proverbs.ts` clean
- [x] `npm run audit` shows no new failures (image coverage 100%, citations balanced)
- [x] `seed-curated-proverbs.ts` is idempotent — re-running does not duplicate rows