### PR TITLE
korean/vietnamese: seed minimum-viable Seon and Thiền cohorts

### DIFF
--- a/public/masters/gihwa.svg
+++ b/public/masters/gihwa.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" width="600" height="600" role="img" aria-label="Hamheo Gihwa — portrait unavailable">
+  <title>Hamheo Gihwa (1376–1433)</title>
+  <desc>Name-card placeholder — no public-domain portrait of this master is available.</desc>
+  <defs>
+    <radialGradient id="paper" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="hsl(280, 14%, 97%)" stop-opacity="1"/>
+      <stop offset="100%" stop-color="hsl(280, 14%, 97%)" stop-opacity="0.88"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="600" fill="url(#paper)"/>
+  <g transform="translate(300 280)">
+    <circle r="200" fill="none" stroke="hsl(280, 25%, 35%)" stroke-width="10" stroke-linecap="round" stroke-dasharray="1230 30" transform="rotate(-18)" opacity="0.85"/>
+    <text y="36.666666666666664" text-anchor="middle" font-family="Songti SC, STSong, Noto Serif CJK TC, serif" font-size="110" fill="hsl(280, 20%, 22%)" style="font-weight:500;">함허기화</text>
+  </g>
+  <text x="300" y="530" text-anchor="middle" font-family="Cormorant Garamond, serif" font-size="26" fill="hsl(280, 20%, 22%)" style="font-weight:500;">Hamheo Gihwa</text>
+  <text x="300" y="562" text-anchor="middle" font-family="Cormorant Garamond, serif" font-size="16" fill="hsl(280, 15%, 50%)" style="letter-spacing:1px;">1376–1433</text>
+  <text x="300" y="586" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="hsl(280, 15%, 50%)" opacity="0.7">portrait unavailable</text>
+</svg>

--- a/public/masters/toui.svg
+++ b/public/masters/toui.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" width="600" height="600" role="img" aria-label="Doui — portrait unavailable">
+  <title>Doui (?–825)</title>
+  <desc>Name-card placeholder — no public-domain portrait of this master is available.</desc>
+  <defs>
+    <radialGradient id="paper" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="hsl(280, 14%, 97%)" stop-opacity="1"/>
+      <stop offset="100%" stop-color="hsl(280, 14%, 97%)" stop-opacity="0.88"/>
+    </radialGradient>
+  </defs>
+  <rect width="600" height="600" fill="url(#paper)"/>
+  <g transform="translate(300 280)">
+    <circle r="200" fill="none" stroke="hsl(280, 25%, 35%)" stroke-width="10" stroke-linecap="round" stroke-dasharray="1230 30" transform="rotate(-18)" opacity="0.85"/>
+    <text y="53.333333333333336" text-anchor="middle" font-family="Songti SC, STSong, Noto Serif CJK TC, serif" font-size="160" fill="hsl(280, 20%, 22%)" style="font-weight:500;">도의</text>
+  </g>
+  <text x="300" y="530" text-anchor="middle" font-family="Cormorant Garamond, serif" font-size="26" fill="hsl(280, 20%, 22%)" style="font-weight:500;">Doui</text>
+  <text x="300" y="562" text-anchor="middle" font-family="Cormorant Garamond, serif" font-size="16" fill="hsl(280, 15%, 50%)" style="letter-spacing:1px;">?–825</text>
+  <text x="300" y="586" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="hsl(280, 15%, 50%)" opacity="0.7">portrait unavailable</text>
+</svg>

--- a/scripts/data/korean-vietnamese-masters.ts
+++ b/scripts/data/korean-vietnamese-masters.ts
@@ -102,12 +102,53 @@ export const KV_SOURCES: KVSource[] = [
     publicationDate: "2006",
     reliability: "scholarly",
   },
+  {
+    id: "src_muller_kihwa",
+    type: "monograph",
+    title:
+      "The Sutra of Perfect Enlightenment: Korean Buddhism's Guide to Meditation (with Commentary by the Sŏn Monk Kihwa)",
+    author: "Muller, A. Charles",
+    publicationDate: "1999",
+    reliability: "scholarly",
+  },
 ];
 
 // ─── Masters ────────────────────────────────────────────────────────────
 
 export const KV_MASTERS: KVMaster[] = [
   // ─── Korean Seon ──────────────────────────────────────────────────────
+  {
+    slug: "toui",
+    schoolSlug: "seon",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Doui" },
+      { locale: "en", nameType: "alias", value: "Toui" },
+      { locale: "ko", nameType: "dharma", value: "도의" },
+      { locale: "zh", nameType: "alias", value: "道義" },
+    ],
+    birthYear: null,
+    birthPrecision: "unknown",
+    birthConfidence: "low",
+    deathYear: 825,
+    deathPrecision: "exact",
+    deathConfidence: "medium",
+    biography:
+      "Doui (道義, d. 825) is the master through whom Southern School Chan first entered the Korean peninsula and is reckoned the founder of the Gajisan school, the earliest of the Nine Mountain Schools (Gusan Seonmun) of Korean Seon. He travelled to Tang China in 784, received transmission from Xitang Zhizang at Mazu Daoyi's Hongzhou community, and returned to Silla in 821 carrying a teaching that the doctrinal establishment of his time received with hostility. Unable to teach publicly, he retired to Jinjeon-sa on Mount Seorak, where his lineage matured under his disciple Yeomgeo and became visible only after his death — a pattern, repeated across the next century by the other Mountain founders, that defined the Korean reception of Chan as a self-consciously meditative alternative to Silla's scholastic Buddhism.",
+    citations: [
+      { sourceId: "src_buswell_formation", pageOrSection: "pp. 1–40", fieldName: "biography" },
+      { sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58", fieldName: "teachers" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "xitang-zhizang",
+        type: "primary",
+        isPrimary: true,
+        sourceIds: ["src_buswell_formation"],
+        notes:
+          "Transmission received in Tang China c. 821 from Mazu Daoyi's principal heir Xitang Zhizang.",
+      },
+    ],
+  },
   {
     slug: "jinul",
     schoolSlug: "jogye",
@@ -201,6 +242,71 @@ export const KV_MASTERS: KVMaster[] = [
         sourceIds: ["src_buswell_formation"],
         notes:
           "Transmission received in Yuan China in 1347; brings the Yangqi-Linji dharma stream into Korea.",
+      },
+    ],
+  },
+  {
+    slug: "naong-hyegeun",
+    schoolSlug: "seon",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Naong Hyegeun" },
+      { locale: "en", nameType: "alias", value: "Naong Hyegun" },
+      { locale: "ko", nameType: "dharma", value: "나옹혜근" },
+      { locale: "zh", nameType: "alias", value: "懶翁惠勤" },
+    ],
+    birthYear: 1320,
+    birthPrecision: "exact",
+    birthConfidence: "high",
+    deathYear: 1376,
+    deathPrecision: "exact",
+    deathConfidence: "high",
+    biography:
+      "Naong Hyegeun (懶翁惠勤, 1320–1376) was — alongside Taego Bou — the second great late-Goryeo master through whom Yuan-dynasty Chinese Chan reached Korea, and the teacher who carried the dharma into the early Joseon. Travelling to Yuan China in 1347, he studied at the great Mongol-period monastery on Mount Yan, received Linji transmission from Pingshan Chulin, and crossed paths with the Indian master Zhikong (Śūnyādiśya), whose memory he later helped to establish in Korea. On returning to Korea he served as Royal Preceptor under King Gongmin and re-articulated the inheritance from China through hwadu practice. His most consequential disciple, Muhak Jacho, in turn taught Hamheo Gihwa and became state preceptor to the founding Joseon king Yi Seong-gye — making Naong the conduit through which the late-Goryeo Linji line continued, however precariously, into the Confucian-suppressed early Joseon.",
+    citations: [
+      { sourceId: "src_buswell_formation", pageOrSection: "pp. 41–74", fieldName: "biography" },
+      { sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–41", fieldName: "teachers" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "taego-bou",
+        type: "dharma",
+        isPrimary: false,
+        sourceIds: ["src_buswell_formation"],
+        notes:
+          "Editorial bridge: Naong and Taego Bou were contemporaries who both received Yuan-Chinese Linji transmission and served as Royal Preceptor under King Gongmin. The edge captures the late-Goryeo Linji cohort to which Naong belongs; his direct teacher Pingshan Chulin is not yet seeded.",
+      },
+    ],
+  },
+  {
+    slug: "gihwa",
+    schoolSlug: "seon",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Hamheo Gihwa" },
+      { locale: "en", nameType: "alias", value: "Hamhŏ Tŭkt'ong" },
+      { locale: "en", nameType: "alias", value: "Kihwa" },
+      { locale: "ko", nameType: "dharma", value: "함허기화" },
+      { locale: "zh", nameType: "alias", value: "涵虛己和" },
+    ],
+    birthYear: 1376,
+    birthPrecision: "exact",
+    birthConfidence: "high",
+    deathYear: 1433,
+    deathPrecision: "exact",
+    deathConfidence: "high",
+    biography:
+      "Hamheo Gihwa (涵虛己和, 1376–1433) was the leading philosophical voice of Korean Buddhism in the first generation of the Joseon dynasty, when the new Neo-Confucian state was systematically dismantling Buddhist institutions. A former Confucian scholar at Seonggyungwan who became a monk under Muhak Jacho — Naong Hyegeun's principal disciple — he turned his classical training to the defense of the dharma in the Hyeonjeong-non (Treatise on Manifesting the Right), a measured response to Confucian polemics that argued for the compatibility of Buddhist liberation with Confucian moral seriousness. His commentaries on the Sutra of Perfect Enlightenment and the Diamond Sutra became standard reading in Korean monasteries and remain among the most subtle works of philosophical Seon ever written, demonstrating that the Korean tradition could continue to think rigorously even under the Joseon state's suppression.",
+    citations: [
+      { sourceId: "src_muller_kihwa", pageOrSection: "Introduction", fieldName: "biography" },
+      { sourceId: "src_buswell_monastic", pageOrSection: "pp. 21–58", fieldName: "teachers" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "naong-hyegeun",
+        type: "dharma",
+        isPrimary: false,
+        sourceIds: ["src_muller_kihwa"],
+        notes:
+          "Editorial bridge: Gihwa's direct teacher was Muhak Jacho (not yet seeded), Naong Hyegeun's principal disciple. The edge captures the Naong → Muhak → Gihwa transmission line that carried late-Goryeo Linji Seon into the early Joseon.",
       },
     ],
   },
@@ -423,6 +529,99 @@ export const KV_MASTERS: KVMaster[] = [
         sourceIds: ["src_nguyen_medieval"],
         notes:
           "Editorial bridge: Trần Nhân Tông's direct teacher was the lay master Tuệ Trung Thượng Sĩ (not yet seeded). In founding Trúc Lâm he unified the Vinītaruci, Vô Ngôn Thông, and Thảo Đường schools; the edge to Vinītaruci is drawn on that lineage-unification basis.",
+      },
+    ],
+  },
+  {
+    slug: "phap-loa",
+    schoolSlug: "truc-lam",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Pháp Loa" },
+      { locale: "vi", nameType: "dharma", value: "Pháp Loa" },
+      { locale: "zh", nameType: "alias", value: "法螺" },
+    ],
+    birthYear: 1284,
+    birthPrecision: "exact",
+    birthConfidence: "high",
+    deathYear: 1330,
+    deathPrecision: "exact",
+    deathConfidence: "high",
+    biography:
+      "Pháp Loa (法螺, 1284–1330) was the second patriarch of the Trúc Lâm school and the master to whom Trần Nhân Tông personally transmitted the dharma in 1308 in front of the assembled monastic community. Where the founder had been an emperor turned hermit, Pháp Loa was the institutional builder who consolidated the new school: he supervised the carving of a complete Vietnamese-edition Buddhist canon, ordained more than fifteen thousand monastics over his patriarchate, and oversaw the construction and reform of monasteries across the Trần realm. The disciplined, scholastic Trúc Lâm that survives in Vietnamese Buddhist memory — as much as the more famous founder — is in large part his work.",
+    citations: [
+      { sourceId: "src_nguyen_medieval", pageOrSection: "pp. 85–123", fieldName: "biography" },
+      { sourceId: "src_le_manh_that", fieldName: "dates" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "tran-nhan-tong",
+        type: "primary",
+        isPrimary: true,
+        sourceIds: ["src_nguyen_medieval"],
+        notes:
+          "Direct transmission from Trần Nhân Tông in 1308; second patriarch of Trúc Lâm.",
+      },
+    ],
+  },
+  {
+    slug: "huyen-quang",
+    schoolSlug: "truc-lam",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Huyền Quang" },
+      { locale: "vi", nameType: "dharma", value: "Huyền Quang" },
+      { locale: "zh", nameType: "alias", value: "玄光" },
+    ],
+    birthYear: 1254,
+    birthPrecision: "exact",
+    birthConfidence: "high",
+    deathYear: 1334,
+    deathPrecision: "exact",
+    deathConfidence: "high",
+    biography:
+      "Huyền Quang (玄光, 1254–1334) was the third and last patriarch of the medieval Trúc Lâm school. A precocious scholar who placed first in the imperial examinations in 1272, he served the Trần court for two decades before being ordained in middle age and entering the dharma circle around Trần Nhân Tông and Pháp Loa. After Pháp Loa's death he assumed the patriarchate at age seventy-seven and spent the final four years of his life at Côn Sơn, where his poetry — among the earliest surviving lyric corpus in Vietnamese Buddhist letters — gives the most personal voice to the school's contemplative ideal. With his death the Trúc Lâm patriarchate passed into a long quiescence from which it would be revived only in the twentieth century.",
+    citations: [
+      { sourceId: "src_nguyen_medieval", pageOrSection: "pp. 85–123", fieldName: "biography" },
+      { sourceId: "src_le_manh_that", fieldName: "dates" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "tran-nhan-tong",
+        type: "dharma",
+        isPrimary: false,
+        sourceIds: ["src_nguyen_medieval"],
+        notes:
+          "Editorial bridge: institutionally Huyền Quang succeeded the second patriarch Pháp Loa, but he was older than Pháp Loa and received his Trúc Lâm formation from the founder Trần Nhân Tông himself. The edge to Trần Nhân Tông keeps the chronology straight while preserving the patriarchal line.",
+      },
+    ],
+  },
+  {
+    slug: "thich-thanh-tu",
+    schoolSlug: "truc-lam",
+    names: [
+      { locale: "en", nameType: "dharma", value: "Thích Thanh Từ" },
+      { locale: "vi", nameType: "dharma", value: "Thích Thanh Từ" },
+      { locale: "zh", nameType: "alias", value: "釋清慈" },
+    ],
+    birthYear: 1924,
+    birthPrecision: "exact",
+    birthConfidence: "high",
+    deathYear: null,
+    deathPrecision: "unknown",
+    deathConfidence: "low",
+    biography:
+      "Thích Thanh Từ (釋清慈, b. 1924) is the master most responsible for the twentieth-century revival of the Trúc Lâm school after six centuries of dormancy. Trained in the Lâm Tế Liễu Quán line under Thích Thiện Hoa, he founded Trúc Lâm Thiền Viện at Đà Lạt in 1993 as an explicit re-grounding of Vietnamese Buddhism in the indigenous Trúc Lâm inheritance of Trần Nhân Tông, Pháp Loa, and Huyền Quang — practiced as a disciplined meditative monasticism rather than a literary memory. From this base he has trained the largest contemporary Vietnamese contemplative community, with Trúc Lâm monasteries now established across Vietnam, North America, Europe, and Australia. Where Thích Nhất Hạnh's Plum Village brought Vietnamese Buddhism into a global lay-mindfulness movement, Thích Thanh Từ has rebuilt it from inside the monastic tradition.",
+    citations: [
+      { sourceId: "src_le_manh_that", fieldName: "biography" },
+      { sourceId: "src_nguyen_medieval", pageOrSection: "pp. 150–175", fieldName: "teachers" },
+    ],
+    transmissions: [
+      {
+        teacherSlug: "lieu-quan",
+        type: "dharma",
+        isPrimary: false,
+        sourceIds: ["src_le_manh_that"],
+        notes:
+          "Editorial bridge: Thích Thanh Từ trained in the Lâm Tế Liễu Quán line under Thích Thiện Hoa (not yet seeded). The edge to Liễu Quán anchors his transmission line; his Trúc Lâm revival reaches back, programmatically, to Trần Nhân Tông.",
       },
     ],
   },

--- a/scripts/generate-llms-full.ts
+++ b/scripts/generate-llms-full.ts
@@ -217,10 +217,18 @@ async function main() {
 
   const lines: string[] = [];
 
+  // Round-down hundreds for "X+" labels so the count rolls forward as the
+  // dataset grows, but the published number stays a stable lower bound.
+  const masterFloor = Math.floor(mastersData.length / 5) * 5;
+  const transmissionFloor = Math.floor(transmissionsData.length / 10) * 10;
+  const teachingFloor = Math.floor(teachingsData.length / 5) * 5;
+
   lines.push("# Zen Lineage — Complete Reference");
   lines.push("");
-  lines.push("> An open-source interactive encyclopedia of Zen Buddhism covering 435+ masters,");
-  lines.push("> 23 schools, 436 lineage transmissions, 363 teachings, and 1,700+ scholarly");
+  lines.push(`> An open-source interactive encyclopedia of Zen Buddhism covering ${masterFloor}+ masters,`);
+  lines.push(
+    `> ${schoolsData.length} schools, ${transmissionFloor}+ lineage transmissions, ${teachingFloor}+ teachings, and 1,700+ scholarly`
+  );
   lines.push("> citations across 2,500 years of Chan, Zen, Seon, and Thien Buddhist history.");
   lines.push("");
   lines.push("Zen Lineage maps the dharma transmission lineages connecting Buddhist masters");


### PR DESCRIPTION
Closes #18.

## Summary

Adds 6 Korean Seon and Vietnamese Thiền masters to `scripts/data/korean-vietnamese-masters.ts` so the 8 Korean/Vietnamese schools that were defined in `school-taxonomy.ts` but had zero seeded masters now satisfy the issue's minimum cohort thresholds (≥10 Korean, ≥8 Vietnamese). Each new master is a slug + names (English + native script + Hanja) + cited biography + transmission edge into the existing graph, all in the same shape as the existing entries.

### New masters

**Korean (now 10 total across `seon` / `jogye` / `kwan-um` / `taego-order`):**
- `toui` — Doui (도의, d. 825), Gajisan Mountain founder. Edge → `xitang-zhizang`.
- `naong-hyegeun` — Naong Hyegeun (나옹혜근, 1320–1376), Royal Preceptor under Gongmin. Editorial bridge → `taego-bou`.
- `gihwa` — Hamheo Gihwa (함허기화, 1376–1433), Joseon-era philosophical defender. Editorial bridge → `naong-hyegeun`.

**Vietnamese (now 8 total across `thien` / `lam-te` / `truc-lam` / `plum-village`):**
- `phap-loa` — Pháp Loa (法螺, 1284–1330), 2nd Trúc Lâm patriarch. Edge → `tran-nhan-tong`.
- `huyen-quang` — Huyền Quang (玄光, 1254–1334), 3rd Trúc Lâm patriarch. Edge → `tran-nhan-tong` (he was older than Pháp Loa, so the institutional succession is recorded as a dharma-line bridge to the founder rather than to the second patriarch).
- `thich-thanh-tu` — Thích Thanh Từ (b. 1924), Trúc Lâm revivalist. Editorial bridge → `lieu-quan`.

### Sources

Existing scholarship — Buswell (Korean Seon, Korean monastic experience, Formation of Ch'an Ideology), Cuong Tu Nguyen (Zen in Medieval Vietnam), Lê Mạnh Thát (Buddhism in Vietnam) — covers all six. Added one source: A. Charles Muller, "The Sutra of Perfect Enlightenment … with Commentary by the Sŏn Monk Kihwa" (1999), which is the canonical English-language scholarship on Gihwa.

### Side change

`scripts/generate-llms-full.ts` was hard-coding "435+ masters, 23 schools, 436 lineage transmissions, 363 teachings" in the lead paragraph; that becomes wrong any time the dataset grows. Replaced with floor-rounded counts derived from the live DB so the file regenerates correctly. (`/schools` page metadata is already dynamic and didn't need changes.)

## Test plan

- [x] `seed-db.ts` + `seed-korean-vietnamese.ts` complete without errors against a fresh `zen.db`.
- [x] `SELECT s.slug, COUNT(m.id) FROM schools s LEFT JOIN masters m ON m.school_id=s.id WHERE s.slug IN (...) GROUP BY s.slug` confirms 10 KO + 8 VN.
- [x] `generate-static-data.ts` produces a `graph.json` with all 6 new nodes attached to the right `schoolSlug`, plus working internal/inbound transmission edges (KO: 7 + 3, VN: 5 + 3) — so `?school=seon`, `?school=thien` etc. resolve to connected subgraphs.
- [x] `register-disk-images.ts` re-binds existing portraits for `naong-hyegeun`, `phap-loa`, `huyen-quang`, `thich-thanh-tu`; `generate-name-placeholders.ts` produces SVG cards for `gihwa` and `toui`.
- [x] `generate-llms-full.ts` runs and emits dynamic counts (`400+ masters, 25 schools, 400+ lineage transmissions, 360+ teachings`).
- [ ] Manual UI smoke test in `next dev`: `/schools`, `/schools/seon`, `/schools/truc-lam`, `/lineage?school=seon`, `/lineage?school=thien`, `/masters/jinul`, `/masters/thich-nhat-hanh`. *(Not run from this fix branch — recommend running before merge.)*