### PR TITLE
firefox overflow: extend wrap+min-width safety to citation/timeline text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1303,6 +1303,11 @@ a.footnote-source-link:hover {
 .detail-name-row > *,
 .detail-actions > *,
 .detail-source-heading > *,
+.detail-source-list > li,
+.detail-link-list > li,
+.timeline-masters > *,
+.timeline-schools > *,
+.timeline-master-link > *,
 .page-header > *,
 .proverb-attribution > *,
 .proverb-tags > * {
@@ -1316,10 +1321,32 @@ a.footnote-source-link:hover {
 .detail-subtitle,
 .detail-section-title,
 .detail-subsection-title,
+.detail-source-heading,
+.detail-source-link,
+.detail-inline-link,
+.detail-link-list a,
+.detail-link-list li,
+.detail-source-list li,
 .detail-muted,
+.timeline-entry-content h3,
+.timeline-entry-content p,
+.timeline-master-name,
+.timeline-school-tag,
+.timeline-cite,
 .proverb-content,
-.proverb-attribution {
+.proverb-attribution,
+.proverb-theme-tag,
+.figure-credit {
   overflow-wrap: anywhere;
+}
+
+/* Long URLs in source links and external references can't rely on word
+ * boundaries — Firefox keeps them as a single unbreakable token unless
+ * `word-break: break-word` is also set. */
+.detail-source-link,
+.footnote-source-link,
+.detail-source-list a {
+  word-break: break-word;
 }
 
 .proverb-attribution {


### PR DESCRIPTION
## Summary

Closes #21.

The existing cross-browser overflow safety block in `src/app/globals.css` covered the hero title, the names list, proverb attribution, and a handful of subtitles — but missed several leaf text containers that hold user-generated or translated content. Firefox is stricter than Chromium about `min-width: auto` on flex/grid items and about treating long CJK / URL / translator strings as single unbreakable tokens, so those gaps surfaced as horizontal overflow on `/masters/[slug]` and other detail pages.

This PR extends the same pattern (no new mechanism, no refactor) to the remaining containers:

- `min-width: 0` added on the flex/grid item parents:
  - `.detail-source-list > li`, `.detail-link-list > li`
  - `.timeline-masters > *`, `.timeline-schools > *`, `.timeline-master-link > *`
- `overflow-wrap: anywhere` added on leaf text containers:
  - Master sources: `.detail-source-heading`, `.detail-source-link`, `.detail-source-list li`
  - Teachers / Students / teaching links: `.detail-link-list a`, `.detail-link-list li`, `.detail-inline-link`
  - Timeline: `.timeline-entry-content h3/p`, `.timeline-master-name`, `.timeline-school-tag`, `.timeline-cite`
  - Proverb tags + image credits: `.proverb-theme-tag`, `.figure-credit`
- `word-break: break-word` added narrowly on `.detail-source-link`, `.footnote-source-link`, `.detail-source-list a` so long source URLs break inside the token, not just at word boundaries (Firefox-specific gap).

## Test plan

- [ ] Open `/masters/dogen` on Firefox latest stable at 320, 375, 414, 768, 1024, 1440 — no horizontal scrollbar, long titles/citations stay inside their card
- [ ] Sweep `/schools/[slug]`, `/proverbs`, `/timeline`, `/about`, `/lineage` controls panel at narrow widths — no horizontal scrollbar appears
- [ ] Regression check on Chrome, Safari, Edge — no new wrapping artifacts inside word boundaries that previously held together