### PR TITLE
masters: drop placeholder portrait caption text

### DIFF
--- a/src/app/masters/[slug]/page.tsx
+++ b/src/app/masters/[slug]/page.tsx
@@ -644,16 +644,12 @@ export default async function MasterDetailPage({ params }: { params: Promise<{ s
                     : "detail-hero-image"
                 }
               />
-              <figcaption className="figure-credit">
-                {publishedImage.type === "placeholder"
-                  ? "Portrait unavailable — name card generated from native script."
-                  : (
-                    <>
-                      {publishedImage.attribution ?? "Portrait via Wikipedia / Commons"}
-                      {publishedImage.license ? ` · ${publishedImage.license}` : ""}
-                    </>
-                  )}
-              </figcaption>
+              {publishedImage.type !== "placeholder" && (
+                <figcaption className="figure-credit">
+                  {publishedImage.attribution ?? "Portrait via Wikipedia / Commons"}
+                  {publishedImage.license ? ` · ${publishedImage.license}` : ""}
+                </figcaption>
+              )}
             </figure>
           )}
           <p className="detail-eyebrow">


### PR DESCRIPTION
## Summary

On master detail pages, when the hero image is the auto-generated SVG name-card placeholder, the figcaption rendered "Portrait unavailable — name card generated from native script." That caption read as noise; the name card already speaks for itself.

This change drops the `<figcaption>` entirely when `publishedImage.type === "placeholder"`. Real portraits still render the existing attribution + license caption unchanged.

Only one occurrence of the placeholder caption string existed in `src/` (`src/app/masters/[slug]/page.tsx`), so no other call sites needed the same treatment.

Closes #41

## Test plan

- [ ] Visit a master detail page with a real portrait — attribution + license caption still appears.
- [ ] Visit a master detail page that falls back to the SVG name-card placeholder — no caption text under the image.
- [ ] `grep -r "Portrait unavailable" src/` returns no results.