### PR TITLE
lineage sidebar: drop hover scale + outline on portrait, keep overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -369,13 +369,10 @@ body {
   border-radius: 4px;
   overflow: hidden;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease;
 }
-.sidebar-image-link:hover,
 .sidebar-image-link:focus-visible {
-  outline: none;
-  transform: scale(1.01);
-  box-shadow: 0 0 0 2px rgba(139, 107, 74, 0.45);
+  outline: 2px solid rgba(139, 107, 74, 0.6);
+  outline-offset: 2px;
 }
 /* Subtle "Open profile" hint that fades in on hover so users know the
    image is interactive without cluttering the static layout. */


### PR DESCRIPTION
Closes #44

## Summary
- Remove `transform: scale(1.01)` and `box-shadow` ring from `.sidebar-image-link:hover, :focus-visible`
- Drop the now-unused `transition: transform/box-shadow` on the base rule
- Keep the existing `::after` "Open profile →" gradient overlay as the sole hover/focus affordance
- Replace the focus indicator with a plain `outline` on `:focus-visible` only, so keyboard users still see focus

## Test plan
- [ ] Hover the sidebar portrait on `/lineage` — image does not scale, no outer outline appears, only "Open profile →" overlay fades in
- [ ] Tab to the portrait link — visible focus outline is present
- [ ] Click the portrait — still navigates to `/masters/<slug>`
- [ ] Rest of the sidebar unaffected