### PR TITLE
lineage: dismiss mobile sidebar with outside taps and tighten its size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1386,8 +1386,42 @@ a.footnote-source-link:hover {
     width: 100%;
   }
 
+  /* Mobile: dock the sidebar as a tight bottom drawer so the lineage
+     canvas above it stays usable. Outside-tap dismiss is wired up in
+     LineageGraph.tsx and is gated to this same 720px breakpoint. */
   .sidebar {
-    width: min(320px, 100vw);
+    position: absolute;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: auto;
+    max-height: 55%;
+    padding: 1rem 1rem;
+    border-left: none;
+    border-top: 1px solid var(--paper-warm);
+    box-shadow: 0 -4px 12px rgba(61, 53, 48, 0.08);
+    overflow-y: auto;
+  }
+
+  .sidebar-name {
+    font-size: 1.05rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .sidebar-image-container {
+    max-width: 96px;
+    float: right;
+    margin: 0 0 0.5rem 0.75rem;
+  }
+
+  .sidebar-image {
+    margin-bottom: 0;
+  }
+
+  .sidebar-actions {
+    margin-top: 0.75rem;
+    clear: both;
   }
 
   .masters-table-th,
@@ -1397,20 +1431,6 @@ a.footnote-source-link:hover {
 
   .master-list-school {
     white-space: normal;
-  }
-}
-
-@media (max-width: 640px) {
-  .sidebar {
-    position: fixed;
-    top: auto;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
-    max-height: 60vh;
-    border-left: none;
-    border-top: 1px solid var(--paper-warm);
   }
 }
 

--- a/src/components/LineageGraph.tsx
+++ b/src/components/LineageGraph.tsx
@@ -270,6 +270,10 @@ export default function LineageGraph() {
   const pixiRef = useRef<PixiState | null>(null);
   const fuseRef = useRef<import("fuse.js").default<GraphNode> | null>(null);
   const zoomRef = useRef<d3.ZoomBehavior<HTMLCanvasElement, unknown> | null>(null);
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  // Set by node pointerdown handlers so the document-level outside-tap
+  // listener can distinguish "tapped a node" from "tapped empty canvas".
+  const nodeJustClickedRef = useRef(false);
 
   const prefersReducedMotion =
     typeof window !== "undefined"
@@ -702,6 +706,7 @@ export default function LineageGraph() {
 
         // Click → sidebar
         c.on("pointerdown", () => {
+          nodeJustClickedRef.current = true;
           setSidebar({
             node,
             schoolName: node.schoolName ?? undefined,
@@ -859,6 +864,35 @@ export default function LineageGraph() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Outside-tap dismiss for the master sidebar on mobile (≤720px). Desktop
+  // keeps the sidebar pinned as a side rail; tapping the canvas there should
+  // not dismiss it.
+  useEffect(() => {
+    if (!sidebar) return;
+    if (typeof window === "undefined") return;
+
+    const mq = window.matchMedia("(max-width: 720px)");
+    const handler = (e: PointerEvent) => {
+      if (!mq.matches) return;
+      // A node-tap fires its PIXI pointerdown handler before the document
+      // listener (the canvas is deeper in the tree), setting this flag. In
+      // that case the new node is already being shown — don't dismiss, or
+      // React batching would collapse the open+close into a no-op flash.
+      if (nodeJustClickedRef.current) {
+        nodeJustClickedRef.current = false;
+        return;
+      }
+      const target = e.target as Node | null;
+      if (target && sidebarRef.current && sidebarRef.current.contains(target)) return;
+      setSidebar(null);
+    };
+
+    document.addEventListener("pointerdown", handler);
+    return () => {
+      document.removeEventListener("pointerdown", handler);
+    };
+  }, [sidebar]);
 
   // Handle focusSlug changes without re-initializing the whole graph
   useEffect(() => {
@@ -1121,7 +1155,7 @@ export default function LineageGraph() {
 
       {/* Sidebar */}
       {sidebar && (
-        <aside className="sidebar">
+        <aside className="sidebar" ref={sidebarRef}>
           <button className="sidebar-close" onClick={() => setSidebar(null)} aria-label="Close">
             ✕
           </button>


### PR DESCRIPTION
Closes #46

## Summary

On viewports ≤720px the master sidebar now dismisses on outside taps and is rendered as a tighter bottom drawer so the lineage canvas above it stays usable. Desktop layout is unchanged.

## Changes

**Outside-tap dismiss (mobile only)** — `src/components/LineageGraph.tsx`
- New `useEffect` attaches a `pointerdown` listener while the sidebar is open and removes it on close/unmount.
- Listener is gated by `matchMedia("(max-width: 720px)")` so desktop is untouched.
- Node taps set a `nodeJustClickedRef` flag in the existing PIXI `pointerdown` handler. The document listener honors that flag so tapping a different node swaps content without a close/re-open flash (avoiding a React-batched no-op when both setSidebar calls land in the same event tick).
- The aside has a `ref` so the listener can ignore taps inside it; the `✕` close button still works.

**Tighter mobile sidebar** — `src/app/globals.css`
- Consolidated the existing 640px/720px sidebar rules into a single `@media (max-width: 720px)` block matching the rest of the lineage mobile layout.
- Sidebar is now `position: absolute; bottom/left/right: 0; width: auto; max-height: 55%` with internal `overflow-y: auto`, `padding: 1rem`, top border + soft shadow so it reads as a bottom drawer.
- Portrait floats right at 96px so the panel stays compact on narrow viewports; `.sidebar-name` and `.sidebar-actions` margins are reduced.

## Test plan
- [ ] On a ~390px-wide viewport, open `/lineage`, tap a master node — sidebar appears at the bottom occupying clearly less than half the screen.
- [ ] Tap the canvas above the sidebar — sidebar closes.
- [ ] Tap a different master node — sidebar swaps content with no flash.
- [ ] Tap the `✕` close button — sidebar closes.
- [ ] On desktop (>720px), tap a node, then tap the canvas — sidebar stays open (unchanged behavior).
- [ ] Pan/zoom still works after opening/closing the sidebar.
- [ ] Tooltip on hover still works.