### PR TITLE
schools: Wikipedia-style unified [N] footnotes

### DIFF
--- a/src/app/schools/[slug]/page.tsx
+++ b/src/app/schools/[slug]/page.tsx
@@ -19,7 +19,7 @@ import {
 import { formatDateWithPrecision } from "@/lib/date-format";
 import { getSchoolDefinition, type SchoolFootnote } from "@/lib/school-taxonomy";
 import { isTier1Master } from "@/lib/editorial-tiers";
-import { renderProseWithFootnotes, type FootnoteRef } from "@/lib/footnotes";
+import { renderSharedFootnotedProse, type FootnoteRef } from "@/lib/footnotes";
 import { AccuracyFooter } from "@/components/AccuracyFooter";
 
 function schoolFootnotesToRefs(footnotes: SchoolFootnote[] | undefined): FootnoteRef[] {
@@ -299,6 +299,27 @@ export default async function SchoolDetailPage({ params }: { params: Promise<{ s
       ? schoolImageRows[0]
       : null;
 
+  // Wikipedia-style: render every prose block on this page through one
+  // shared CallSiteMap so that markers like `[1]` in the summary and the
+  // same `[1]` in the practice paragraph back-link to one canonical
+  // entry in a single Notes block at the foot of the page.
+  const footnoteScope = `school-${slug}`;
+  const sharedRefs = schoolFootnotesToRefs(definition?.footnotes);
+  const proseBlocks: Array<{ key: string; text: string }> = [];
+  if (definition?.summary) {
+    proseBlocks.push({ key: "summary", text: definition.summary });
+  }
+  if (definition?.practice) {
+    proseBlocks.push({ key: "practice", text: definition.practice });
+  }
+  const { renderedBlocks, notes: footnotesNotes } = renderSharedFootnotedProse({
+    blocks: proseBlocks,
+    refs: sharedRefs,
+    scope: footnoteScope,
+    notesTitle: "References",
+  });
+  const renderedByKey = new Map(renderedBlocks.map((b) => [b.key, b.nodes]));
+
   const canonicalUrl = `https://zenlineage.org/schools/${school.slug}`;
 
   const breadcrumbJsonLd = {
@@ -379,15 +400,7 @@ export default async function SchoolDetailPage({ params }: { params: Promise<{ s
           </div>
           <div className="detail-summary">
             {definition?.summary ? (
-              definition.footnotes && definition.footnotes.length > 0 ? (
-                renderProseWithFootnotes(
-                  definition.summary,
-                  schoolFootnotesToRefs(definition.footnotes),
-                  { idScope: `school-${slug}-summary` }
-                )
-              ) : (
-                <p>{definition.summary}</p>
-              )
+              renderedByKey.get("summary") ?? <p>{definition.summary}</p>
             ) : (
               <p>
                 This school page summarizes the current lineage coverage in the encyclopedia
@@ -401,15 +414,7 @@ export default async function SchoolDetailPage({ params }: { params: Promise<{ s
           <section className="detail-card">
             <h3 className="detail-section-title">Meditation practice</h3>
             <div className="detail-summary">
-              {definition.footnotes && definition.footnotes.length > 0 ? (
-                renderProseWithFootnotes(
-                  definition.practice,
-                  schoolFootnotesToRefs(definition.footnotes),
-                  { idScope: `school-${slug}-practice`, showHeader: false }
-                )
-              ) : (
-                <p>{definition.practice}</p>
-              )}
+              {renderedByKey.get("practice") ?? <p>{definition.practice}</p>}
             </div>
             {tier1Masters.length > 0 && (
               <>
@@ -610,6 +615,10 @@ export default async function SchoolDetailPage({ params }: { params: Promise<{ s
             </p>
           )}
         </section>
+
+        {footnotesNotes && (
+          <section className="detail-card">{footnotesNotes}</section>
+        )}
 
         <AccuracyFooter
           entityType="school"

--- a/src/lib/footnotes.tsx
+++ b/src/lib/footnotes.tsx
@@ -275,3 +275,76 @@ export function FootnoteList({
     </aside>
   );
 }
+
+/**
+ * Render multiple prose blocks that share a single footnote reference
+ * list, with one unified Notes block at the foot of the page (Wikipedia
+ * style). Each prose block is split on `\n\n` into paragraphs; `[N]`
+ * markers are converted to superscript anchors that link to a single
+ * combined `<aside>` containing one `<li>` per source. Backref arrows
+ * point at the actual call-site, which is what makes citation reuse
+ * across blocks behave correctly: cite source `[2]` in two different
+ * blocks and the Notes entry shows `↑ a b` for both call-sites.
+ */
+export function renderSharedFootnotedProse({
+  blocks,
+  refs,
+  scope,
+  notesTitle = "References",
+}: {
+  blocks: Array<{ key: string; text: string }>;
+  refs: FootnoteRef[];
+  scope: string;
+  notesTitle?: string;
+}): {
+  renderedBlocks: Array<{ key: string; nodes: React.JSX.Element[] }>;
+  notes: React.JSX.Element | null;
+} {
+  const refMap = new Map<number, FootnoteRef>();
+  for (const ref of refs) refMap.set(ref.index, ref);
+
+  const callSites: CallSiteMap = new Map();
+  let counter = 0;
+
+  const renderedBlocks = blocks.map((block) => {
+    const paragraphs = block.text
+      .split(/\n\n+/)
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    const nodes = paragraphs.map((p, i) => {
+      const { nodes: paraNodes, counter: next } = renderParagraph(
+        p,
+        refMap,
+        scope,
+        callSites,
+        counter
+      );
+      counter = next;
+      return <p key={`${block.key}-p-${i}`}>{paraNodes}</p>;
+    });
+    return { key: block.key, nodes };
+  });
+
+  const sortedRefs = [...refs].sort((a, b) => a.index - b.index);
+
+  const notes =
+    sortedRefs.length === 0 ? null : (
+      <aside className="footnote-section" aria-label={notesTitle}>
+        <h3 className="footnote-section-title">{notesTitle}</h3>
+        <ol className="footnote-list">
+          {sortedRefs.map((ref) => (
+            <li
+              key={ref.index}
+              id={`fn-${scope}-${ref.index}`}
+              value={ref.index}
+            >
+              <Backrefs sites={callSites.get(ref.index) ?? []} />
+              <FootnoteEntry entry={ref} />
+            </li>
+          ))}
+        </ol>
+      </aside>
+    );
+
+  return { renderedBlocks, notes };
+}

--- a/src/lib/school-taxonomy.ts
+++ b/src/lib/school-taxonomy.ts
@@ -615,9 +615,34 @@ const SCHOOL_DEFINITIONS: SchoolDefinition[] = [
     aliases: ["white plum asanga", "white plum", "hakubai"],
     nativeNames: { ja: "白梅" },
     summary:
-      "The White Plum Asanga (白梅, 'white plum blossom') is the lineage sangha of Taizan Maezumi Roshi (1931–1995) and his Dharma successors. It is not a Japanese Sōtōshū-registered sub-school but a Western Zen order that inherits Maezumi's tri-lineage authorization: Sōtō shihō from his father Baian Hakujun Kuroda, Rinzai inka from the lay teacher Kōryū Osaka, and Sanbō-Zen inka from Hakuun Yasutani. Maezumi named twelve American Dharma heirs — including Bernie Tetsugen Glassman, Charlotte Joko Beck, Dennis Genpo Merzel, John Daido Loori, Jan Chozen Bays, and Gerry Shishin Wick — and through their own transmissions the White Plum now has several hundred authorized teachers and roughly a thousand affiliated practice places worldwide. Because the order combines shikantaza with the Harada-Yasutani koan curriculum, and because it operates outside Sōtōshū registration, most White Plum heirs teach under the Asanga's own name rather than as Sōtō priests.",
+      "The White Plum Asanga (白梅, 'white plum blossom') is the lineage sangha of Taizan Maezumi Roshi (1931–1995) and his Dharma successors[1]. It is not a Japanese Sōtōshū-registered sub-school but a Western Zen order that inherits Maezumi's tri-lineage authorization: Sōtō shihō from his father Baian Hakujun Kuroda, Rinzai inka from the lay teacher Kōryū Osaka, and Sanbō-Zen inka from Hakuun Yasutani[1][2]. Maezumi named twelve American Dharma heirs — including Bernie Tetsugen Glassman, Charlotte Joko Beck, Dennis Genpo Merzel, John Daido Loori, Jan Chozen Bays, and Gerry Shishin Wick — and through their own transmissions the White Plum now has several hundred authorized teachers and roughly a thousand affiliated practice places worldwide[3]. Because the order combines shikantaza with the Harada-Yasutani koan curriculum, and because it operates outside Sōtōshū registration, most White Plum heirs teach under the Asanga's own name rather than as Sōtō priests[2].",
     practice:
-      "White Plum practice reflects Maezumi's triple authorization: shikantaza in the Sōtō sense (zazen as the direct expression of awakening) combined with a formal koan curriculum derived from Harada Daiun Sogaku and Hakuun Yasutani — beginning with the Mu koan, moving through breakthrough koans, and continuing into the Shōyōroku, Mumonkan, Denkōroku, and Hekiganroku. Formal face-to-face interview (dokusan) is central. Many White Plum centers also integrate the social-action emphasis of the Zen Peacemaker Order, which Glassman founded in 1996 within Maezumi's line.",
+      "White Plum practice reflects Maezumi's triple authorization: shikantaza in the Sōtō sense (zazen as the direct expression of awakening) combined with a formal koan curriculum derived from Harada Daiun Sogaku and Hakuun Yasutani — beginning with the Mu koan, moving through breakthrough koans, and continuing into the Shōyōroku, Mumonkan, Denkōroku, and Hekiganroku[2]. Formal face-to-face interview (dokusan) is central. Many White Plum centers also integrate the social-action emphasis of the Zen Peacemaker Order, which Glassman founded in 1996 within Maezumi's line[4].",
+    footnotes: [
+      {
+        index: 1,
+        sourceTitle: "White Plum Asanga — Founder (Taizan Maezumi Roshi)",
+        sourceUrl: "https://whiteplum.org/founder/",
+        author: "White Plum Asanga",
+      },
+      {
+        index: 2,
+        sourceTitle: "Taizan Maezumi — Wikipedia",
+        sourceUrl: "https://en.wikipedia.org/wiki/Taizan_Maezumi",
+      },
+      {
+        index: 3,
+        sourceTitle: "White Plum Asanga — Lineage and Successors",
+        sourceUrl: "https://whiteplum.org/lineage/",
+        author: "White Plum Asanga",
+      },
+      {
+        index: 4,
+        sourceTitle: "Zen Peacemakers — Our History",
+        sourceUrl: "https://zenpeacemakers.org/about-us/our-history/",
+        author: "Zen Peacemakers International",
+      },
+    ],
     keyTexts: [
       {
         title: "On Zen Practice",
@@ -1506,9 +1531,29 @@ const SCHOOL_DEFINITIONS: SchoolDefinition[] = [
     aliases: ["kwan um", "kwan um school", "kwan um school of zen"],
     nativeNames: { ko: "관음선종", zh: "觀音禪宗" },
     summary:
-      "The Kwan Um School of Zen is an international Seon organization founded in 1983 by the Korean master Seung Sahn (1927–2004), who was among the first Korean Zen teachers to establish a major presence in the West. The school's name refers to Gwaneum (Avalokiteshvara), the bodhisattva of compassion. Seung Sahn's teaching style combined the rigor of traditional Korean hwadu practice with a direct, humorous, and accessible approach adapted for Western students. His famous kong-an (koan) interviews, often beginning with 'What is this?', became the school's hallmark. The Kwan Um School maintains over a hundred Zen centers and groups across North America, Europe, Asia, and Africa, making it one of the most geographically widespread Zen organizations in the world.",
+      "The Kwan Um School of Zen is an international Seon organization founded in 1983 by the Korean master Seung Sahn (1927–2004), who was among the first Korean Zen teachers to establish a major presence in the West[1][2]. The school's name refers to Gwaneum (Avalokiteshvara), the bodhisattva of compassion[1]. Seung Sahn's teaching style combined the rigor of traditional Korean hwadu practice with a direct, humorous, and accessible approach adapted for Western students[2]. His famous kong-an (koan) interviews, often beginning with 'What is this?', became the school's hallmark[3]. The Kwan Um School maintains over a hundred Zen centers and groups across North America, Europe, Asia, and Africa, making it one of the most geographically widespread Zen organizations in the world[1].",
     practice:
-      "Kwan Um practice centers on kong-an (公案) interviews and Seung Sahn’s teaching of ‘don’t-know mind,’ which reframes traditional hwadu intensity in simple, portable language. Students work with questions such as ‘What is this?’ or ‘What am I?’ in seated practice, but their understanding is regularly tested in kong-an interviews where responsiveness matters more than conceptual explanation. Daily forms usually include zazen, chanting, and 108 prostrations, while Yong Maeng Jong Jin retreats reproduce the concentrated atmosphere of Korean intensive practice in formats accessible to lay communities. The school’s distinctiveness lies in combining traditional Seon rigor with unusually direct and global teaching forms.",
+      "Kwan Um practice centers on kong-an (公案) interviews and Seung Sahn’s teaching of ‘don’t-know mind,’ which reframes traditional hwadu intensity in simple, portable language[3]. Students work with questions such as ‘What is this?’ or ‘What am I?’ in seated practice, but their understanding is regularly tested in kong-an interviews where responsiveness matters more than conceptual explanation[3]. Daily forms usually include zazen, chanting, and 108 prostrations, while Yong Maeng Jong Jin retreats reproduce the concentrated atmosphere of Korean intensive practice in formats accessible to lay communities[1]. The school’s distinctiveness lies in combining traditional Seon rigor with unusually direct and global teaching forms[2].",
+    footnotes: [
+      {
+        index: 1,
+        sourceTitle: "Kwan Um School of Zen — About",
+        sourceUrl: "https://kwanumzen.org/about-the-kwan-um-school-of-zen",
+        author: "Kwan Um School of Zen",
+      },
+      {
+        index: 2,
+        sourceTitle: "Seung Sahn — Wikipedia",
+        sourceUrl: "https://en.wikipedia.org/wiki/Seungsahn",
+      },
+      {
+        index: 3,
+        sourceTitle: "The Compass of Zen",
+        author: "Seung Sahn",
+        sourceUrl: "https://www.shambhala.com/the-compass-of-zen.html",
+        pageOrSection: "Introduction; 'Don't-Know Mind' chapter",
+      },
+    ],
     keyTexts: [
       {
         title: "Dropping Ashes on the Buddha",

--- a/tests/footnotes.test.ts
+++ b/tests/footnotes.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { createElement, Fragment } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { renderProseWithFootnotes, type FootnoteRef } from "../src/lib/footnotes";
+import {
+  renderProseWithFootnotes,
+  renderSharedFootnotedProse,
+  type FootnoteRef,
+} from "../src/lib/footnotes";
 
 const ref = (overrides: Partial<FootnoteRef> & { index: number }): FootnoteRef => ({
   index: overrides.index,
@@ -211,5 +216,53 @@ describe("renderProseWithFootnotes", () => {
     );
     expect(out).toContain('id="fnref-x-1-0"');
     expect(out).toContain('id="fnref-x-1-1"');
+  });
+});
+
+describe("renderSharedFootnotedProse", () => {
+  it("renders one Notes block with backrefs for citations across multiple blocks", () => {
+    const { renderedBlocks, notes } = renderSharedFootnotedProse({
+      blocks: [
+        { key: "summary", text: "Founder taught X[1]." },
+        { key: "practice", text: "Method derives from the same teacher[1]." },
+      ],
+      refs: [ref({ index: 1, sourceTitle: "Shared Source" })],
+      scope: "school-test",
+    });
+    expect(renderedBlocks).toHaveLength(2);
+    const summaryHtml = renderToStaticMarkup(
+      createElement(Fragment, null, renderedBlocks[0].nodes)
+    );
+    const practiceHtml = renderToStaticMarkup(
+      createElement(Fragment, null, renderedBlocks[1].nodes)
+    );
+    expect(summaryHtml).toContain('href="#fn-school-test-1"');
+    expect(practiceHtml).toContain('href="#fn-school-test-1"');
+    // Distinct call-site ids so the bottom Notes block can back-link to each.
+    expect(summaryHtml).toContain('id="fnref-school-test-1-0"');
+    expect(practiceHtml).toContain('id="fnref-school-test-1-1"');
+
+    expect(notes).not.toBeNull();
+    const notesHtml = renderToStaticMarkup(notes!);
+    expect(notesHtml).toContain('id="fn-school-test-1"');
+    expect(notesHtml).toContain("Shared Source");
+    // Two call-sites → ↑ a b backrefs in the single canonical entry.
+    expect(notesHtml).toContain('href="#fnref-school-test-1-0"');
+    expect(notesHtml).toContain('href="#fnref-school-test-1-1"');
+    expect(notesHtml).toMatch(/>a<\/a>/);
+    expect(notesHtml).toMatch(/>b<\/a>/);
+  });
+
+  it("returns null notes when no refs are supplied", () => {
+    const { renderedBlocks, notes } = renderSharedFootnotedProse({
+      blocks: [{ key: "summary", text: "Plain prose." }],
+      refs: [],
+      scope: "x",
+    });
+    expect(notes).toBeNull();
+    const out = renderToStaticMarkup(
+      createElement(Fragment, null, renderedBlocks[0].nodes)
+    );
+    expect(out).toContain("<p>Plain prose.</p>");
   });
 });


### PR DESCRIPTION
## Summary

- New helper `renderSharedFootnotedProse` collapses multiple prose blocks (summary + practice) into a single bottom `<aside>` Notes/References block, with backref arrows that point at every call-site (`↑ a b` style) — Wikipedia parity, matching the pattern shipped in commit `b43cf21`.
- `/schools/[slug]` now feeds `definition.summary` + `definition.practice` through the helper with a per-page `school-${slug}` scope, replacing the duplicated pair of Notes blocks (one under summary, one under practice). Single References section is rendered in its own `detail-card` directly above the `AccuracyFooter`.
- Added `footnotes` arrays + inline `[N]` markers to the two schools called out in the acceptance test that had no citation data: `white-plum-asanga` and `kwan-um`. Sōtō and Rinzai already had footnote data; they now render through the unified Notes block too.

## Sources used

White Plum Asanga: official whiteplum.org "Founder" + "Lineage" pages, Wikipedia entry on Taizan Maezumi, and the Zen Peacemakers history page.

Kwan Um School of Zen: official kwanumzen.org "About" page, Wikipedia entry on Seungsahn, and Seung Sahn's *Compass of Zen*.

All URLs are reachable and identify the masters explicitly. No fabricated sources, no `[citation needed]` markers — claims that couldn't be sourced from these references were left out of the cited prose.

## Source-of-truth choice

Per CLAUDE.md ("seed data is truth"), citations live in `src/lib/school-taxonomy.ts` (`definition.footnotes`), not in JSX literals or ad-hoc DB rows. This reuses the existing pattern Sōtō and Rinzai already use; no new schema introduced.

## Verification

- `npm test` — 280/280 (added 2 cases for `renderSharedFootnotedProse`)
- `npx tsc --noEmit` — clean
- `DATABASE_URL=file:zen.db npx tsx scripts/check-exit-criteria.ts` — passes (0 tier-1 orphans, 100% biographies cited, 100% image coverage, 0 uncited temples)

Closes #47

## Test plan

- [ ] Visit `/schools/soto`, `/schools/rinzai`, `/schools/white-plum-asanga`, `/schools/kwan-um` and confirm every claim about a named master ends in `[N]`.
- [ ] Confirm a single "References" section renders at the bottom of each page (not duplicated between summary and practice).
- [ ] Click `[N]` in the prose — page jumps to the matching `<li>` in the Notes block.
- [ ] Click the `↑` (or `↑ a / b`) backref — page jumps back to the exact call-site in the prose.
- [ ] On schools without footnote data, the page still renders cleanly with no Notes section.