### PR TITLE
masters + schools: justify body text on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -922,6 +922,8 @@ a.footnote-source-link:hover {
   line-height: 1.7;
   text-align: justify;
   overflow-wrap: anywhere;
+  hyphens: auto;
+  -webkit-hyphens: auto;
 }
 
 .detail-summary blockquote {
@@ -1370,9 +1372,9 @@ a.footnote-source-link:hover {
     padding-right: 1rem;
   }
 
-  /* Narrow-width justification creates uneven word-spacing that reads as
-   * visual noise. Fall back to left alignment below the tablet breakpoint. */
-  .detail-summary,
+  /* Citations stay left-aligned on narrow screens — short excerpts in
+   * justified mode produce awkward gaps. Body prose keeps its base
+   * justified treatment, mitigated by hyphens: auto. */
   .detail-source-excerpt {
     text-align: left;
   }


### PR DESCRIPTION
## Summary

- Removes the `@media (max-width: 720px)` override that forced `.detail-summary` back to `text-align: left`, so master biographies and school summaries/practice prose inherit the justified treatment used on desktop.
- Adds `hyphens: auto` (and `-webkit-hyphens: auto`) to the base `.detail-summary` rule so long words wrap/hyphenate, mitigating the uneven word-spacing that originally motivated the mobile override (commit 2e16d16). Document `lang="en"` is already set in `src/app/layout.tsx`, so hyphenation will activate.
- Leaves `.detail-source-excerpt` (citation excerpts) left-aligned on mobile — short excerpts read worse when justified, and the issue scopes the change to masters/schools body text only.

## Test plan

- [ ] Visit `/masters/dogen` on a ≤720px viewport — biography is justified, no huge word gaps.
- [ ] Visit `/schools/soto` on a ≤720px viewport — both summary and "Meditation practice" prose are justified.
- [ ] Desktop appearance unchanged on the same pages.
- [ ] Citation excerpts (`.detail-source-excerpt`) remain left-aligned on mobile.

Closes #54