### PR TITLE
home: fix mobile overlap between content and stats footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,6 +88,33 @@ body {
   }
 }
 
+/* Homepage layout — desktop pins the stats line to the bottom of the
+ * viewport. On mobile the centered column gets tall (the 8-item nav wraps
+ * to several rows, plus a multi-line proverb), so an absolute footer
+ * collides with the content. Below 640px we let it flow naturally and
+ * tighten the nav gap so it doesn't fan into too many rows. */
+.home-stats {
+  position: absolute;
+  bottom: 2rem;
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .home-main {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .home-nav {
+    gap: 1rem 1.5rem !important;
+  }
+
+  .home-stats {
+    position: static;
+    margin-top: 3rem;
+  }
+}
+
 /* ===== Page header (shared) =====
  * The header shares the same 860px content column as the detail pages and
  * list pages, so on wide viewports the breadcrumb stays aligned with the

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -164,7 +164,7 @@ export default async function Home() {
 
   return (
     <main
-      className="flex min-h-screen flex-col items-center justify-center px-6 text-center"
+      className="home-main flex min-h-screen flex-col items-center justify-center px-6 text-center"
       style={{ background: "var(--paper)" }}
     >
       <script
@@ -212,6 +212,7 @@ export default async function Home() {
 
       {/* Nav links */}
       <nav
+        className="home-nav"
         style={{
           display: "flex",
           gap: "2.5rem",
@@ -284,8 +285,6 @@ export default async function Home() {
       <p
         className="home-stats"
         style={{
-          position: "absolute",
-          bottom: "2rem",
           fontFamily: "var(--font-inter), sans-serif",
           fontSize: "0.6rem",
           letterSpacing: "0.12em",


### PR DESCRIPTION
## Summary
- The homepage's centered column overlapped its absolute-positioned stats footer on mobile because the 8-item nav wraps to several rows and the daily proverb runs multiple lines.
- Below 640px, drop `.home-stats` into normal flow with a top margin and tighten `.home-nav` gap so it fans across fewer rows.
- Add `.home-main` / `.home-nav` hooks on `src/app/page.tsx` so the breakpoint can target homepage chrome without affecting the desktop layout.

Closes #59

## Test plan
- [ ] Load `/` on a 320–414px wide viewport and confirm logograph, wordmark, nav, proverb, and stats stack with breathing room (no overlap).
- [ ] Verify desktop (≥768px) still pins the stats line to the bottom of the viewport unchanged.